### PR TITLE
Project GitHub URLs must be fully qualified.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,8 +4,14 @@ class Project < ActiveRecord::Base
   validates_presence_of :description, :github_url, :name, :main_language
   validates_uniqueness_of :github_url, :message => "already been submitted"
   validates_length_of :description, :within => 20..200
+  validate :github_url_is_fully_qualified
 
   LANGUAGES = ["ActionScript", "Assembly", "C", "C#", "C++", "Clojure", "CoffeeScript",
                "CSS", "Emacs Lisp", "Erlang", "Haskell", "HTML", "Java", "JavaScript", 
                "Lua", "Objective-C", "Perl", "PHP", "Python", "Ruby", "Scala", "Scheme"]
+
+private
+  def github_url_is_fully_qualified
+    errors.add :github_url, "must be fully qualified (beginning with http://)" unless github_url =~ /\Ahttp\:\/\//
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,12 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ :name => 'Chicago' }, { :name => 'Copenhagen' }])
-#   Mayor.create(:name => 'Emanuel', :city => cities.first)
+# Test the cleanup script
+fully_qualified = Project.create \
+  description: 'this should have a fully qualified url',
+  github_url: 'http://github.com/fully/qualified',
+  name: 'qualified',
+  main_language: 'Ruby'
+relative = Project.new \
+  description: 'this should have a relative github url',
+  github_url: 'github.com/dontwork/relative_path',
+  name: 'relative_relative',
+  main_language: 'Ruby'
+relative.save(validate: false)

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,0 +1,10 @@
+namespace :cleanup do
+  desc "Make Projects with relative GitHub URLs fully-qualified"
+  task :projects => :environment do
+    Project.all.each do |project|
+      project.update_attributes(github_url: "http://#{project.github_url}") \
+        unless project.github_url =~ /\Ahttp\:\/\//
+      puts "URL of #{project.name} is '#{project.github_url}'" if project.save
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Project do
+  it "disallows projects with relative urls to be created" do
+    project = Project.new \
+      description: 'test test test test test',
+      github_url: 'github.com/test/test',
+      name: 'test',
+      main_language: 'Ruby'
+
+    project.should_not be_valid
+    project.errors.full_messages.should include("Github url must be fully qualified (beginning with http://)")
+    project.errors.full_messages.count.should == 1
+  end
+end


### PR DESCRIPTION
We should make sure each Project's github_url is fully qualified. Otherwise, you get cases such as this link to Coffee-Toaster..  `github.com/serpentem/coffee-toaster`. So here ya go! All you have to do is run the Rake task on production to convert any projects that don't begin with "http://", and each Project submission from here on out validates that the github_url begins with "http://".
- Add validator to Project that tests whether GitHub URLs begin with "http://"
- Test validation in specs
- Add Rake task for cleaning up old Projects without fully-qualified
  URLs. It should be run on the production server once after deploying
  the code in this Pull Request.
- Add test data to db/seeds.rb for testing the Rake task. Verify that
  the task works in dev by typing `rake db:seed cleanup:projects`. All
  projects should be prefixed with one "http://", no matter how many
  times you run the task.
