### PR TITLE
Fix footer links on mobile

### DIFF
--- a/app/assets/stylesheets/site.css.scss
+++ b/app/assets/stylesheets/site.css.scss
@@ -162,7 +162,14 @@ footer {
     background:#434343;
 
     ul {
-      margin-top: 30px;
+      margin-top: -45px;
+
+      @media (max-width: 767px) {
+        float: none;
+        text-align: center;
+        margin: 15px 0;
+      }
+
       li {
         border-left: 1px solid #333;
         display: inline-block;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -66,19 +66,17 @@
   %footer
     .dark
       .dark-inner
-        %ul.unstyled.pull-left
-          %li
-            = link_to 'About', about_path()
-
+        .logo.logo-dark
         %ul.unstyled.pull-right
           %li
             Sponsored by&nbsp;
             = link_to 'DNSimple', 'http://dnsimple.com'
             &nbsp;&amp;&nbsp;
             = link_to 'Cooper Press', 'http://cooperpress.com'
-
-        .logo.logo-dark
-
+            
+        %ul.unstyled.pull-left
+          %li
+            = link_to 'About', about_path()
 
     .ftw
       Open Source FTW!


### PR DESCRIPTION
Footer links show below the logo when displayed on mobile devices. There is no change on regular desktop browsers.

This fixes issue #49 but for some reason I am not able to push this to the issue itself.
