### PR TITLE
Added an additional language filter on the view-all projects page for ColdFusion

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,7 +6,7 @@ class Project < ActiveRecord::Base
   validates_length_of :description, :within => 20..200
 
   LANGUAGES = ["ActionScript", "Assembly", "C", "C#", "C++", "Clojure", "CoffeeScript",
-               "CSS", "Emacs Lisp", "Erlang", "Haskell", "HTML", "Java", "JavaScript", 
+               "ColdFusion", "CSS", "Emacs Lisp", "Erlang", "Haskell", "HTML", "Java", "JavaScript", 
                "Lua", "Objective-C", "Perl", "PHP", "PowerShell", "Python", "Ruby",
                "Scala", "Scheme", "Shell"]
 end


### PR DESCRIPTION
There are a bunch of submitted projects associated with the ColdFusion language, so I thought I'd add it as a filter option.
