### PR TITLE
Remove server.rb

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -1,5 +1,0 @@
-require 'sinatra'
-
-get '/' do
-  erb :index
-end


### PR DESCRIPTION
Looks like this app started off as a Sinatra app, and later migrated to
Rails.  Sinatra is no longer in the Gemfile, so it seems like this file
is no longer needed.
