### PR TITLE
Proper capitalisation on nouns, pronouns; Twitter defaults to HTTPS

### DIFF
--- a/app/views/static/about.html.haml
+++ b/app/views/static/about.html.haml
@@ -1,18 +1,18 @@
 %h2 About 24 Pull Requests
 
-%p 24 Pull Requests is a little project to promote open source collaboration during december.
+%p 24 Pull Requests is a little project to promote open source collaboration during December.
 
-%p The idea is basically "Send a pull request every day in december leading up to Christmas", encouraging developers to give back to open source with little gifts of code throughout december.
+%p The idea is basically "Send a pull request every day in December leading up to Christmas", encouraging developers to give back to open source with little gifts of code throughout December.
 
-%p The site also provides suggested projects to help with, guides for contributing and highlight good pull requests submitted each day.
-
-%p
-  The site development is open source on github: 
-  = link_to 'https://github.com/andrew/24pullrequests', 'https://github.com/andrew/24pullrequests'
+%p The site also provides suggested projects to help with, guides for contributing and highlights good pull requests submitted each day.
 
 %p
-  We are also on twitter:
-  = link_to 'http://twitter.com/24pullrequests', 'http://twitter.com/24pullrequests'
+  The site development is open source on GitHub: 
+  = link_to 'github.com/andrew/24pullrequests', 'https://github.com/andrew/24pullrequests'
+
+%p
+  We are also on Twitter:
+  = link_to 'twitter.com/24pullrequests', 'https://twitter.com/24pullrequests'
 
 %section
   %h3 Sponsors


### PR DESCRIPTION
December and GitHub should be spelt with the proper casing of the first
letter for both, the humpy H in the case of the latter.

Twitter redirects all links to HTTPS version, clean it up a little by
just showing the twitter.com without the leading http since people
rarely enter that part of a URL any more.
