### PR TITLE
A rake task to consolidate project records that were added before the va...

### DIFF
--- a/lib/tasks/data_cleanup.rake
+++ b/lib/tasks/data_cleanup.rake
@@ -4,14 +4,9 @@ task :deduplicate_projects => :environment do
   duplicate_project_groups = Project.all.group_by(&:github_url).select { |k, v| v.count > 1 }
 
   duplicate_project_groups.values.each do |project_group|
-
-    earliest     = project_group.sort_by(&:created_at).first
-    descriptions = project_group.map(&:description).join(", ")
+    earliest = project_group.sort_by(&:created_at).first
 
     (project_group - [earliest]).map(&:destroy)
-
-    earliest.description = descriptions
-    earliest.save!
   end
 
 end


### PR DESCRIPTION
...lidation of a unique github_url was added.

Since 2ebe41fd4b4152ed2f60bffc48d751aad936067d, it hasn't been possible to add projects that have the same github url as something else already added, but there are still some projects in the production db that were added before that validation (rails/rails, hotsh/rstat.us).

This rake task will find those duplicates, save all their descriptions on the earliest one (since the descriptions might be different), and delete all but the earliest record.

I also have an alternative approach that I started that consolidates the Projects that have the same github_url at the view level and just displays one project with multiple descriptions. It's on this branch: https://github.com/carols10cents/24pullrequests/tree/consolidate_duplicates_in_view 

I'd be happy to submit that branch as a PR instead if you'd like, but while working through it, it felt like this should really just be cleaned up in the database.

Thank you so much for this project, I love it! :heart: :heart: :heart: 
