### PR TITLE
Added placeholder for programming languages in new projects form

### DIFF
--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -4,7 +4,7 @@
   = form.input :name, :input_html => {:class => "span4"}
   = form.input :github_url, :input_html => {:class => "span4"}
   = form.input :description, :input_html => {:rows => 5, :class => "span4"}, :label => 'Summary'
-  = form.input :main_language, :input_html => {:class => "span4", :data => {:provide => "typeahead", :source => Project::LANGUAGES}, :autocomplete => 'off'}
+  = form.input :main_language, :input_html => {:class => "span4", :data => {:provide => "typeahead", :source => Project::LANGUAGES}, :autocomplete => 'off', :placeholder => "Ruby, C++, Java, Python..."}
   .control-group
     .controls
       = form.button :submit, 'Submit Project'


### PR DESCRIPTION
Now it is more clear, that these are programming languages, not speaking languages. Made this mistake myself, but I am not the only one.
