### PR TITLE
Enable multi language filter in projects_path

### DIFF
--- a/app/assets/javascripts/projects.js.coffee
+++ b/app/assets/javascripts/projects.js.coffee
@@ -8,7 +8,7 @@ $ ->
     return false unless clicked_language?
 
     unless event.ctrlKey or event.metaKey
-      languages = [$(this).data().language]
+      languages.concat $(this).data().language
     else
       unless clicked_language in languages
         languages.push clicked_language


### PR DESCRIPTION
To filter more than two language [projects_path](http://24pullrequests.com/projects), use Cmd or Ctrl key when selecting language.
This behavior is well known in many OS, so people will be want to use
this when filtering multi languages.
