### PR TITLE
Add VimL to list of acceptable languages

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,25 +1,18 @@
 class Project < ActiveRecord::Base
   attr_accessible :description, :github_url, :name, :main_language
 
+  LANGUAGES = ["ActionScript", "Assembly", "C", "C#", "C++", "Clojure", "CoffeeScript",
+               "ColdFusion", "CSS", "Emacs Lisp", "Erlang", "Groovy", "Haskell", "HTML", "Java", "JavaScript", 
+               "Lua", "Objective-C", "OCaml", "Perl", "PHP", "PowerShell", "Python", "Ruby",
+               "Scala", "Scheme", "Shell", "VimL"]
+
   validates_presence_of :description, :github_url, :name, :main_language
   validates_format_of :github_url, :with => /^https?:\/\/(www\.)?github.com\/[\w-]*\/[\w-]*(\/)?$/i, :message => 'Enter the full HTTP URL.'
   validates_uniqueness_of :github_url, :message => "Project has already been suggested."
   validates_length_of :description, :within => 20..200
-  validate :main_language_available?, :message => " can not add this language"
-
-  LANGUAGES = ["ActionScript", "Assembly", "C", "C#", "C++", "Clojure", "CoffeeScript",
-               "ColdFusion", "CSS", "Emacs Lisp", "Erlang", "Groovy", "Haskell", "HTML", "Java", "JavaScript", 
-               "Lua", "Objective-C", "OCaml", "Perl", "PHP", "PowerShell", "Python", "Ruby",
-               "Scala", "Scheme", "Shell"]
+  validates_inclusion_of :main_language, :in => LANGUAGES, :message => 'must be a programming language'
 
   def github_repository
     self.github_url.gsub(/^(((https|http|git)?:\/\/(www\.)?)|git@)github.com(:|\/)/i, '').gsub(/(\.git|\/)$/i, '')
   end
-
-  def main_language_available?
-    unless LANGUAGES.include?(self.main_language)
-      errors.add(:main_language, ' must be a programming language')
-    end
-  end
-
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -16,8 +16,8 @@ describe Project do
   it "Validation should not pass on wrong programming language" do
     project = FactoryGirl.build(:project)
     project.main_language = "English"
-    project.valid?
-    project.errors[:main_language].include?(" must be a programming language").should be_true
+    project.valid?.should_not be_true
+    project.errors[:main_language].include?('must be a programming language').should be_true
   end
 
   it "Validation should pass on correct programming language" do


### PR DESCRIPTION
Additionally, fix an assertion in the `Project` spec and simplify
the `main_language` validation.

Signed-off-by: David Celis me@davidcel.is
