### PR TITLE
Enable multi language filter in projects_path

### DIFF
--- a/app/assets/javascripts/projects.js.coffee
+++ b/app/assets/javascripts/projects.js.coffee
@@ -6,10 +6,7 @@ $ ->
     clicked_language = $(this).data().language
 
     unless clicked_language?
-      $('#languages li').removeClass('disabled')
-      $('#projects').html(projects.find('.project'))
-      projects = $('#projects').clone()
-      $('#projects').css('height', 'auto')
+      resetLanguage()
       return
 
     unless e.ctrlKey or e.metaKey
@@ -22,7 +19,9 @@ $ ->
 
     $('#noprojects').hide()
 
-    if languages.length > 0
+    unless languages.length > 0
+      resetLanguage()
+    else
       $('#languages li')
         .addClass('disabled')
         .find($.map(languages, (l) -> "a[data-language=#{l}]").join(','))
@@ -32,3 +31,9 @@ $ ->
       $('#projects').quicksand $(projects).find(".#{languages.join(', .')}"), duration: 0, ->
         if $('#projects .project:visible').length == 0
           $('#noprojects').show()
+
+  resetLanguage = ->
+      $('#languages li').removeClass('disabled')
+      $('#projects').html(projects.find('.project'))
+      projects = $('#projects').clone()
+      $('#projects').css('height', 'auto')


### PR DESCRIPTION
To filter more than two language [projects_path](http://24pullrequests.com/projects), use Cmd or Ctrl key
when selecting language.
This behavior is well known in many OS, so people will be want to use
this when filtering multi languages.
