### PR TITLE
Fixing style to maintain text on top of 24 logo

### DIFF
--- a/app/assets/stylesheets/site.css.scss
+++ b/app/assets/stylesheets/site.css.scss
@@ -163,6 +163,7 @@ footer {
 
     ul {
       margin-top: -45px;
+      position: relative;
 
       @media (max-width: 767px) {
         float: none;


### PR DESCRIPTION
The footer 24 logo on top of text "Sponsored by ...".
DOM element `footer .dark ul` needs a position rule to fix the elements order.
