### PR TITLE
Spread Christmas into its full length word, not the abbreviation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 
 “Giving back little gifts of code”
 
-24 Pull Requests is a yearly initiative to encourage developers around the world to send a pull request every day in December up to Xmas.
+24 Pull Requests is a yearly initiative to encourage developers around the world to send a pull request every day in December up to Christmas.
 
 This is the site to help promote the project, highlighting why, how and where to send your pull requests.
 
@@ -22,7 +22,7 @@ This is the site to help promote the project, highlighting why, how and where to
 ## Development
 
 Source hosted at [GitHub](http://github.com/andrew/24pullrequests).
-Report Issues/Feature requests on [GitHub Issues](http://github.com/andrew/24pullrequests/issues). Follow us on Twitter [@24pullrequests](https://twitter.com/24pullrequests).
+Report issues/feature requests on [GitHub Issues](http://github.com/andrew/24pullrequests/issues). Follow us on Twitter [@24pullrequests](https://twitter.com/24pullrequests).
 
 ### Getting Started
 

--- a/app/views/dashboards/show.html.haml
+++ b/app/views/dashboards/show.html.haml
@@ -1,12 +1,12 @@
 %h2
   Welcome back, #{user.nickname}
 
-%p This is where you can see all the activity we've tracked for you in the run up to Xmas.
+%p This is where you can see all the activity we've tracked for you in the run up to Christmas.
 
 %hr
 
 - if gift_form
-  Looks like you haven't gifted any code today. Would you like too gift
+  Looks like you haven't gifted any code today. Would you like to gift
   = render :partial => 'gifts/mini_form', :locals => { :gift_form => gift_form }
   %hr
 

--- a/app/views/static/homepage.html.haml
+++ b/app/views/static/homepage.html.haml
@@ -7,14 +7,14 @@
   .span6
     %h2 What it's all about?
     %hr
-    %p 24 Pull Requests is a yearly initiative to encourage developers around the world to send a pull request every day in December up to Xmas.
+    %p 24 Pull Requests is a yearly initiative to encourage developers around the world to send a pull request every day in December up to Christmas.
     %p This is the site to help promote the project, highlighting why, how and where to send your pull requests.
-    %p Log in with your Github account and we'll track and highlight all your pull requests and suggest projects to work on.
+    %p Log in with your GitHub account and we'll track and highlight all your pull requests and suggest projects to work on.
     %hr
     - unless logged_in?
       %p
         = link_to login_path, :class => 'btn' do
-          %strong Log in with Github
+          %strong Log in with GitHub
       %hr
     = render :partial => 'shared/social_buttons'
 
@@ -29,7 +29,7 @@
 
     %h4 Build your profile
     %hr
-    %p Contributing to open source projects is also a great way to build your profile in the community and improve your cv.
+    %p Contributing to open source projects is also a great way to build your profile in the community and improve your CV.
     %p It's really easy to get started, even small contributions can be really valuable to a project.
 
 #users.row-fluid.clearfix


### PR DESCRIPTION
Not sure if it's a deliberate style choice, but perhaps we could have "Christmas" as that and not the shortened "Xmas" version.
- CV is capital letters due to being an initialism
- GitHub button should include the humpy capital H
