### PR TITLE
Easily switch on GitHub while developing

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -13,4 +13,4 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET']
 end
 
-Rails.application.config.default_provider = Rails.env.development? ? :developer2 : :github
+Rails.application.config.default_provider = (Rails.env.development? && ENV['GITHUB_KEY'].blank?) ? :developer2 : :github

--- a/config/initializers/pull_requests_downloader.rb
+++ b/config/initializers/pull_requests_downloader.rb
@@ -1,4 +1,4 @@
-Rails.application.config.pull_request_downloader = if Rails.env.production?
+Rails.application.config.pull_request_downloader = if Rails.env.production? || !ENV['GITHUB_KEY'].blank?
                                                      ->(login, oauth_token) { PullRequestDownloader.new(login, oauth_token) }
                                                    else
                                                      ->(login, oauth_token) { Struct.new(:pull_requests).new([]) }


### PR DESCRIPTION
It's hard to work with pull request data without having a real GitHub
application set up. Now login and real pull request downloading are available
in development if `ENV['GITHUB_KEY']` is present.
