### PR TITLE
Don't render HTML links in plain text mails

### DIFF
--- a/app/views/reminder_mailer/daily.text.erb
+++ b/app/views/reminder_mailer/daily.text.erb
@@ -14,7 +14,7 @@ Suggested Projects
 
 <% @suggested_projects.each do |project| %>
 <%= project.name %>
-<%= link_to project.github_url, project.github_url %>
+<%= project.github_url %>
 <%= project.main_language %>
 <%= project.description %>
 

--- a/app/views/reminder_mailer/weekly.text.erb
+++ b/app/views/reminder_mailer/weekly.text.erb
@@ -14,7 +14,7 @@ Suggested Projects
 
 <% @suggested_projects.each do |project| %>
 <%= project.name %>
-<%= link_to project.github_url, project.github_url %>
+<%= project.github_url %>
 <%= project.main_language %>
 <%= project.description %>
 


### PR DESCRIPTION
link_to always renders HTML links, even in text views.

I have been trying to implement a test that catches this as well, but I'm not able to actually run the tests because of something in my environment (I've tried for hours) :-(, so maybe this is completely broken, but I tried:

```
--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -28,2 +28,6 @@ describe ReminderMailer do

+    it 'does not contain html links in text alternative' do
+      mail.text_part.should_not include('<a href=')
+    end
+
   end
```
