### PR TITLE
Let twitter_token be accessible

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ActiveRecord::Base
-  attr_accessible :uid, :provider, :nickname, :email, :gravatar_id, :token, :email_frequency, :skills_attributes
+  attr_accessible :uid, :provider, :nickname, :email, :gravatar_id, :token, :email_frequency, :skills_attributes, :twitter_token
 
   attr_writer :gift_factory
 


### PR DESCRIPTION
I ran into a little problem when trying to run rake db:seed:

Inserting some test data
rake aborted!
undefined local variable or method `twitter_token' for #User:0x00000003739da0

This PR fixes it.
