### PR TITLE
Restrict pull requests to being gifted on a single day each

### DIFF
--- a/app/controllers/gifts_controller.rb
+++ b/app/controllers/gifts_controller.rb
@@ -9,7 +9,7 @@ class GiftsController < ApplicationController
 
   def new
     gift_form = GiftForm.new(:gift           => current_user.new_gift,
-                             :pull_requests  => current_user.pull_requests,
+                             :pull_requests  => current_user.unspent_pull_requests,
                              :giftable_dates => Gift.giftable_dates,
                              :date => params[:date])
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -131,6 +131,11 @@ class User < ActiveRecord::Base
     )
   end
 
+  def unspent_pull_requests
+    gifted_pull_requests = gifts.map {|g| g.pull_request }
+    pull_requests.reject{|pr| gifted_pull_requests.include?(pr) }
+  end
+  
   private
   def pull_request_downloader
     Rails.application.config.pull_request_downloader.call(nickname, token)


### PR DESCRIPTION
Added method to user object to return only pull requests that had not already been gifted.

Closes #168.
