### PR TITLE
Restrict 'gift-able' pull requests on the dashboard to the ungifted ones.

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -9,7 +9,7 @@ class DashboardsController < ApplicationController
 
     if is_decemeber? && !current_user.gift_for(today)
       gift      = current_user.new_gift
-      gift_form = GiftForm.new(:gift => gift, :pull_requests => pull_requests)
+      gift_form = GiftForm.new(:gift => gift, :pull_requests => current_user.unspent_pull_requests)
     end
 
     render :show, :locals => { :user => current_user,


### PR DESCRIPTION
Dashboard was showing all pull_requests as available for gifting on the current day, updated controller to use User#unspent_pull_requests instead.
