### PR TITLE
Email copy

### DIFF
--- a/app/views/dashboards/preferences.html.haml
+++ b/app/views/dashboards/preferences.html.haml
@@ -1,6 +1,9 @@
 %h2 Set your Email Preferences 
 
-%p At the frequency you choose, we'll send you helpful emails from now until the project is over, highlighting some suggested projects you might consider contributing to. As an added bonus, we'll take the liberty of personalizing our suggestions to your language proficiency you've demonstrated in your Github profile based on your repos. Alterately, you can choose your languages below. 
+%p At the frequency you choose, we'll send you helpful emails from now until the project is over, highlighting some suggested projects you might consider contributing to. As an added bonus, we'll take the liberty of personalizing our suggestions to your language proficiency you've demonstrated in your Github profile based on your repos. Alterately, you can choose your languages below.
+
+%p 
+  %em You can always change your email preferences later.
 
 = simple_form_for current_user, :url => update_preferences_path, :html => {:class => 'form-horizontal'}  do |form|
   = form.input :email


### PR DESCRIPTION
Addresses issue #25: Add copy to email preferences page that works for new or returning users
