### PR TITLE
Alternatively is the optional word of choice; Drops some your

### DIFF
--- a/app/views/dashboards/preferences.html.haml
+++ b/app/views/dashboards/preferences.html.haml
@@ -1,6 +1,6 @@
 %h2 Set your Email Preferences 
 
-%p At the frequency you choose, we'll send you helpful emails from now until the project is over, highlighting some suggested projects you might consider contributing to. As an added bonus, we'll take the liberty of personalizing our suggestions to your language proficiency you've demonstrated in your Github profile based on your repos. Alterately, you can choose your languages below.
+%p At the frequency you choose, we'll send you helpful emails from now until the project is over, highlighting some suggested projects you might consider contributing to. As an added bonus, we'll take the liberty of personalizing our suggestions to your language proficiency based on the repos in your GitHub profile. Alternatively, you can choose your languages below.
 
 %p 
   %em You can always change your email preferences later.


### PR DESCRIPTION
Small typo using "alterately" when asking for languages to base
the emails on.

Too many uses of "your" in a sentence sounds stilted. Then realised
both "demonstrated" and "based on" are the same thing, so excised
one to improve overall reading flow.
