### PR TITLE
Prevent elements jumping when spinner appears

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.less
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.less
@@ -77,6 +77,6 @@ h1, h2, h3, h4, h5, h6 {
   text-rendering: auto;
 }
 
-#spinner {
-  padding-top: 10px;
+#spinner img {
+  margin-top: 10px;
 }


### PR DESCRIPTION
Currently, when spinner appears, "YOUR PULL REQUESTS" title moves a little bit down.
