### PR TITLE
Fixed mailer spec

### DIFF
--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -20,7 +20,7 @@ describe ReminderMailer do
     end
  
     it 'renders the sender email' do
-      mail.from.should == ['24 Pull Requests <info@24pullrequests.com>']
+      mail['From'].to_s.should == '24 Pull Requests <info@24pullrequests.com>'
     end
  
     it 'uses nickname' do
@@ -51,7 +51,7 @@ describe ReminderMailer do
     end
  
     it 'renders the sender email' do
-      mail.from.should == ['24 Pull Requests <info@24pullrequests.com>']
+      mail['From'].to_s.should == '24 Pull Requests <info@24pullrequests.com>'
     end
  
     it 'uses nickname' do


### PR DESCRIPTION
mail.from was stripping the name and only returning the email address, so instead checking the full "From" header looks correct.
