### PR TITLE
Missing words on header note and contributing tips page

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -83,7 +83,7 @@
 
             %p Merry Christmas and see you all next year when we do it all again!
             %hr
-            %p Still want to help out with open source projects? Check out these other great initialitives:
+            %p Still want to help out with open source projects? Check out these other great initiatives:
 
             %h4= link_to 'CodeTriage', 'http://www.codetriage.com/'
             
@@ -92,7 +92,7 @@
             %h4= link_to 'ContribHub', 'http://contribhub.co/'
             
             %p Do you know you have a neighbor needing some help with a really cool project? With ContribHub you will!
-            %p ContribHub is a GitHub-based application that makes easier to find projects to contribute and grow community around it.
+            %p ContribHub is a GitHub-based application that makes it easier to find projects to contribute to and grow a community around it.
             
         .row-fluid
           .span12

--- a/app/views/static/contributing.html.haml
+++ b/app/views/static/contributing.html.haml
@@ -18,7 +18,7 @@
   %li
     %p
       %strong Convention fixes -
-      are mostly binary checks names IsFoo() but one is named Foo_exists() ? do a quick refactor patch for it. Is one Exception named oddly, or have an unclear message?
+      are most binary checks named IsFoo() but one is named Foo_exists() ? Do a quick refactor patch for it. Is one Exception named oddly, or have an unclear message?
   %li
     %p
       %strong Examples -
@@ -30,7 +30,7 @@
   %li
     %p
       %strong Testing -
-      clone the repo and run the tests, do you get any failures, do you notice any areas lacking in coverage? Testing is also a great way to find out more about the internal working of the project.
+      clone the repo and run the tests. Do you get any failures? Do you notice any areas lacking in coverage? Testing is also a great way to find out more about the internal workings of the project.
 
 %h3 Other guides online
 


### PR DESCRIPTION
Blurb for ContribHub is missing a couple of words
to make it read well.

Some tips on "Contributing" are also missing words
