### PR TITLE
Refreshed Gemfile.lock file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,10 @@ group :development, :test do
 end
 
 group :test do
-  gem "capybara", '1.1.4'
+  gem "capybara"
+  gem 'capybara-webkit'
+  gem 'launchy'
+
   gem 'database_cleaner'
   gem 'shoulda-matchers'
   gem 'webmock', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,13 +36,16 @@ GEM
       httparty (>= 0.6, < 1.0)
       multi_json (~> 1.0)
     builder (3.0.4)
-    capybara (1.1.4)
+    capybara (2.0.2)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       selenium-webdriver (~> 2.0)
-      xpath (~> 0.1.4)
+      xpath (~> 1.0.0)
+    capybara-webkit (0.14.2)
+      capybara (~> 2.0, >= 2.0.2)
+      json
     chai-jquery-rails (1.1.1)
       railties (~> 3.1)
       sprockets
@@ -129,6 +132,8 @@ GEM
       colorize
       railties (>= 3.1, < 5)
       sprockets
+    launchy (2.2.0)
+      addressable (~> 2.3)
     less (2.3.1)
       commonjs (~> 0.2.6)
     less-rails (2.3.2)
@@ -184,12 +189,10 @@ GEM
       multi_json (~> 1.3)
       omniauth-oauth (~> 1.0)
     pg (0.14.1)
-    poltergeist (1.0.2)
-      capybara (~> 1.1)
-      childprocess (~> 0.3)
+    poltergeist (1.1.0)
+      capybara (~> 2.0, >= 2.0.1)
       faye-websocket (~> 0.4, >= 0.4.4)
       http_parser.rb (~> 0.5.3)
-      multi_json (~> 1.0)
     polyglot (0.3.3)
     pry (0.9.12)
       coderay (~> 1.0.5)
@@ -309,7 +312,7 @@ GEM
       addressable (>= 2.2.7)
       crack (>= 0.3.2)
     websocket (1.0.7)
-    xpath (0.1.4)
+    xpath (1.0.0)
       nokogiri (~> 1.3)
 
 PLATFORMS
@@ -317,7 +320,8 @@ PLATFORMS
 
 DEPENDENCIES
   bugsnag
-  capybara (= 1.1.4)
+  capybara
+  capybara-webkit
   chai-jquery-rails
   coffee-rails (~> 3.2.1)
   dalli
@@ -332,6 +336,7 @@ DEPENDENCIES
   jquery-rails (= 2.1.4)
   kaminari
   konacha
+  launchy
   less-rails
   memcachier
   minitest (= 3.5.0)

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -58,8 +58,8 @@ describe 'Projects' do
 
       it 'should show both projects by default' do
         within '#projects' do
-          page.should have_content 'Ruby project'
-          page.should have_content 'Java project'
+          page.should have_selector('h4', text: /Java project/i)
+          page.should have_selector('h4', text: /Ruby project/i)
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,8 @@ Spork.prefork do
 
   WebMock.disable_net_connect! :allow_localhost => true
 
+  # To run specs headless, use :webkit driver:
+  Capybara.javascript_driver = :webkit
   if ENV['POLTERGEIST']
     require 'capybara/poltergeist'
     Capybara.javascript_driver = :poltergeist
@@ -75,6 +77,7 @@ Spork.prefork do
     config.infer_base_class_for_anonymous_controllers = false
 
     config.include FactoryGirl::Syntax::Methods
+    config.include Capybara::DSL
   end
 end
 
@@ -85,7 +88,7 @@ Spork.each_run do
     config.before do
       User.any_instance.stub(:estimate_skills).and_return(nil)
       Twitter::Client.any_instance.stub(:update)
-      Timecop.freeze(Date.parse('12/12/2012'))
+      Timecop.travel(Date.parse('12/12/2012'))
     end
 
     config.after do


### PR DESCRIPTION
- Rebuilt Gemfile.lock file to refresh Gemfile.
- Used https instead of http in Gemfile.
- Added minitest(3.5.0) to get green test run.
- FYI: See 5 shoulda_matcher **deprecated and will be removed in 2.0** warnings.
- FYI: Tests are not totally headless but it worked.
- FYI: Here are other ways for me to help:  http://pastie.org/6582928

2nd Commit includes: 
- Upgraded capybara to current version.
- Added capybara-webkit to get headless test run.
- Test run is all green.

Will use branches from now on.
