### PR TITLE
Cleanly upgraded capybara from 2.0.2 to 2.1.0. Green test run

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ group :development, :test do
 end
 
 group :test do
-  gem "capybara", '2.0.2'
+  gem "capybara"
   gem 'capybara-webkit'
   gem 'launchy'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,13 +48,12 @@ GEM
       httparty (>= 0.6, < 1.0)
       multi_json (~> 1.0)
     builder (3.0.4)
-    capybara (2.0.2)
+    capybara (2.1.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
-      selenium-webdriver (~> 2.0)
-      xpath (~> 1.0.0)
+      xpath (~> 2.0)
     capybara-webkit (1.0.0)
       capybara (~> 2.0, >= 2.0.2)
       json
@@ -151,7 +150,7 @@ GEM
       sprockets
     launchy (2.3.0)
       addressable (~> 2.3)
-    listen (1.1.6)
+    listen (1.2.0)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
@@ -201,9 +200,9 @@ GEM
       multi_json (~> 1.3)
       omniauth-oauth (~> 1.0)
     pg (0.15.1)
-    poltergeist (1.1.2)
-      capybara (~> 2.0.1)
-      faye-websocket (~> 0.4.4)
+    poltergeist (1.3.0)
+      capybara (~> 2.1.0)
+      faye-websocket (>= 0.4.4, < 0.5.0)
       http_parser.rb (~> 0.5.3)
     polyglot (0.3.3)
     pry (0.9.12.2)
@@ -267,20 +266,14 @@ GEM
     ruby_gntp (0.3.4)
     ruby_parser (3.1.3)
       sexp_processor (~> 4.1)
-    rubyzip (0.9.9)
     safe_yaml (0.9.3)
     sass (3.2.9)
     sass-rails (3.2.6)
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    selenium-webdriver (2.33.0)
-      childprocess (>= 0.2.5)
-      multi_json (~> 1.0)
-      rubyzip
-      websocket (~> 1.0.4)
     sexp_processor (4.2.1)
-    shoulda-matchers (2.1.0)
+    shoulda-matchers (2.2.0)
       activesupport (>= 3.0.0)
     simple_form (2.1.0)
       actionpack (~> 3.0)
@@ -331,8 +324,7 @@ GEM
     webmock (1.11.0)
       addressable (>= 2.2.7)
       crack (>= 0.3.2)
-    websocket (1.0.7)
-    xpath (1.0.0)
+    xpath (2.0.0)
       nokogiri (~> 1.3)
 
 PLATFORMS
@@ -342,7 +334,7 @@ DEPENDENCIES
   anjlab-bootstrap-rails
   brakeman
   bugsnag
-  capybara (= 2.0.2)
+  capybara
   capybara-webkit
   chai-jquery-rails
   coffee-rails


### PR DESCRIPTION
Cleanly upgraded capybara from 2.0.2 to 2.1.0; Green test run.
In the past, this upgrade broke tests. Now it does not.
