### PR TITLE
Update ContribHub link to new URL - Fixes #284

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -86,7 +86,7 @@
             
             %p Give back to open source, one issue at a time, with CodeTriage. You'll get one issue from your favorite repo per day to help you dig deeper, learn more, and stay involved with the code you rely on.
             
-            %h4= link_to 'ContribHub', 'http://contribhub.co/'
+            %h4= link_to 'ContribHub', 'http://contribhub.com/'
             
             %p Do you know you have a neighbor needing some help with a really cool project? With ContribHub you will!
             %p ContribHub is a GitHub-based application that makes it easier to find projects to contribute to and grow a community around it.


### PR DESCRIPTION
No longer using the .co domain, it's now at http://contribhub.com/
