### PR TITLE
Add alternate ways to find projects to static Contributing page

### DIFF
--- a/app/views/static/contributing.html.haml
+++ b/app/views/static/contributing.html.haml
@@ -32,10 +32,22 @@
       %strong Testing -
       clone the repo and run the tests. Do you get any failures? Do you notice any areas lacking in coverage? Testing is also a great way to find out more about the internal workings of the project.
 
-%h3 Other guides online
+%h3 Other guides to contributing
 
 %ul
   %li= link_to 'Using Pull Requests', 'https://help.github.com/articles/using-pull-requests'
   %li= link_to 'A quick guide to pull requests', 'http://beust.com/weblog/2010/09/15/a-quick-guide-to-pull-requests/'
   %li= link_to 'You (yes, you!) should contribute to open source', 'http://thechangelog.com/post/5367356233/you-yes-you-should-contribute-to-open-source'
   %li= link_to 'How to contribute a patch to a GitHub hosted Open Source project', 'http://www.hanselman.com/blog/GetInvolvedInOpenSourceTodayHowToContributeAPatchToAGitHubHostedOpenSourceProjectLikeCode52.aspx'
+
+%h3 Other ways to find projects
+
+%p Looking for other projects to help? Check out these great initiatives:
+
+%h4= link_to 'CodeMontage', 'http://codemontage.com/'
+
+%p Give forward by contributing to open source, social good projects that benefit organizations making a difference in the world.
+
+%h4= link_to 'CodeTriage', 'http://www.codetriage.com/'
+
+%p Give back to open source, one issue at a time, with CodeTriage. You'll get one issue from your favorite repo per day to help you dig deeper, learn more, and stay involved with the code you rely on.


### PR DESCRIPTION
This is a content addition to the Contributing page so that ways to find projects persist once the December 2013 campaign begins (and the temporary notice goes away).

![24pullrequests_addwaystofindprojects-2](https://f.cloud.github.com/assets/226228/1556950/b932b594-4ef5-11e3-8711-c12069b409c7.png)
