### PR TITLE
rails 4 uses asset-url instead of the other stuff it used to

### DIFF
--- a/app/assets/stylesheets/site.css.scss
+++ b/app/assets/stylesheets/site.css.scss
@@ -28,7 +28,7 @@ section {
   position: absolute;
   width: 100%;
   height: 600px;
-  background-image: image-url('header-snow.png');
+  background-image: asset-url('header-snow.png');
   background-repeat: repeat;
 }
 .header-background {
@@ -66,7 +66,7 @@ section {
   height: $height;
   left: 50%;
   margin-left: -$width/2;
-  background: url('/assets/logo.png') no-repeat bottom;
+  background: asset-url("logo.png") no-repeat bottom;
 
   a {
     position: absolute;
@@ -76,7 +76,7 @@ section {
   }
 
   &.logo-dark {
-    background: url('/assets/logo-dark.png') no-repeat bottom;
+    background: asset-url('logo-dark.png') no-repeat bottom;
   }
 }
 
@@ -104,7 +104,7 @@ header {
     left: 50%;
     margin-left: -$width/2;
     padding-top: 40px;
-    background: transparent url('/assets/tagline.png') no-repeat bottom;
+    background: transparent asset-url('tagline.png') no-repeat bottom;
   }
 }
 


### PR DESCRIPTION
Noticed that image assets served from the css were broken in production, so this fixes that.
