### PR TITLE
Removed trailing white space in 2 specs

### DIFF
--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -1,28 +1,28 @@
 require "spec_helper"
 
 describe ReminderMailer do
-  
+
   describe 'daily' do
-    let(:user) { mock_model(User, :nickname => 'David', 
-                                  :email => 'david@example.com', 
-                                  :languages => ['Ruby'], 
-                                  :skills => [], 
+    let(:user) { mock_model(User, :nickname => 'David',
+                                  :email => 'david@example.com',
+                                  :languages => ['Ruby'],
+                                  :skills => [],
                                   :pull_requests => double(:pull_request, :year => []),
                                   :suggested_projects => []) }
     let(:mail) { ReminderMailer.daily(user) }
- 
+
     it 'renders the subject' do
       mail.subject.should == '[24 Pull Requests] Daily Reminder'
     end
- 
+
     it 'renders the receiver email' do
       mail.to.should == [user.email]
     end
- 
+
     it 'renders the sender email' do
       mail['From'].to_s.should == '24 Pull Requests <info@24pullrequests.com>'
     end
- 
+
     it 'uses nickname' do
       mail.body.encoded.should match(user.nickname)
     end
@@ -34,26 +34,26 @@ describe ReminderMailer do
   end
 
   describe 'weekly' do
-    let(:user) { mock_model(User, :nickname => 'David', 
-                                  :email => 'david@example.com', 
-                                  :languages => ['Ruby'], 
-                                  :skills => [], 
+    let(:user) { mock_model(User, :nickname => 'David',
+                                  :email => 'david@example.com',
+                                  :languages => ['Ruby'],
+                                  :skills => [],
                                   :pull_requests => double(:pull_request, :year => []),
                                   :suggested_projects => []) }
     let(:mail) { ReminderMailer.weekly(user) }
- 
+
     it 'renders the subject' do
       mail.subject.should == '[24 Pull Requests] Weekly Reminder'
     end
- 
+
     it 'renders the receiver email' do
       mail.to.should == [user.email]
     end
- 
+
     it 'renders the sender email' do
       mail['From'].to_s.should == '24 Pull Requests <info@24pullrequests.com>'
     end
- 
+
     it 'uses nickname' do
       mail.body.encoded.should match(user.nickname)
     end

--- a/spec/models/quote_spec.rb
+++ b/spec/models/quote_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 describe Quote do
-  
+
 end


### PR DESCRIPTION
Removed trailing spaces in 2 specs: reminder_mailer_spec.rb and quote_spec.rb.
