### PR TITLE
Replace capybara-webkit with poltergeist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,4 @@ env:
 script:
   - RAILS_ENV=test POLTERGEIST=true bundle exec rake --trace db:migrate spec konacha:run
 before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - psql -c 'create database tfpullrequests_test' -U postgres

--- a/Gemfile
+++ b/Gemfile
@@ -56,14 +56,13 @@ group :development, :test do
 end
 
 group :test do
-  gem "capybara"
-  gem 'capybara-webkit'
+  gem 'capybara'
+  gem 'poltergeist'
   gem 'launchy'
 
   gem 'database_cleaner'
   gem 'shoulda-matchers'
   gem 'webmock', :require => false
-  gem 'poltergeist'
   gem 'timecop'
 
   gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,9 +53,6 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.0.0)
-      capybara (~> 2.0, >= 2.0.2)
-      json
     celluloid (0.15.2)
       timers (~> 1.1.0)
     chai-jquery-rails (1.2.1)
@@ -358,7 +355,6 @@ DEPENDENCIES
   brakeman
   bugsnag
   capybara
-  capybara-webkit
   chai-jquery-rails
   coffee-rails
   coveralls

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,12 +27,8 @@ Spork.prefork do
 
   WebMock.disable_net_connect! :allow_localhost => true
 
-  # To run specs headless, use :webkit driver:
-  Capybara.javascript_driver = :webkit
-  if ENV['POLTERGEIST']
-    require 'capybara/poltergeist'
-    Capybara.javascript_driver = :poltergeist
-  end
+  require 'capybara/poltergeist'
+  Capybara.javascript_driver = :poltergeist
 
   # Requires supporting ruby files with custom matchers and macros, etc,
   # in spec/support/ and its subdirectories.


### PR DESCRIPTION
Use poltergeist instead of capybara-webkit.

capybara-webkit needs Qt C extensions to compile which make things harder.

[fixes #315]
