### PR TITLE
Disable the snowflakes on iOS to resolve scrolling issues.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -99,6 +99,11 @@ function reset(flake) {
 }
 
 function init() {
+
+    // the snowflakes cause a scrolling display issue with iOS
+    if( /iPhone|iPad|iPod/i.test(navigator.userAgent) )
+      return;
+
     for (var i = 0; i < flakeCount; i++) {
         var x = Math.floor(Math.random() * canvas.width),
             y = Math.floor(Math.random() * canvas.height),


### PR DESCRIPTION
I visited the website from a link on my iPad4. After signing in and scrolling down the page, I noticed the issue below. Confirmed it on my iPhone4s.  No issue on my only Android tablet.  

It appears to be an issue with the snowflakes.  If can't fix that easily, but I can suggest turning off the snowflakes until a full solution can be found. 

Here's the problem this commit resolves:

Looks fine when I view it...
![image](https://f.cloud.github.com/assets/148768/1648031/9fe00b96-5968-11e3-9c83-358a4234f662.jpg)

Turns all red when I scroll the page. 
![image](https://f.cloud.github.com/assets/148768/1648033/add6d96e-5968-11e3-9e38-48f3ed363c25.jpg)

The page returns when I stop scrolling. 
