### PR TITLE
Sticky footer

### DIFF
--- a/app/assets/stylesheets/site.css.scss
+++ b/app/assets/stylesheets/site.css.scss
@@ -1,10 +1,16 @@
 @import 'variables.css.scss';
 
+html {
+  position: relative;
+  min-height: 100%;
+}
+
 body{
   background-color: $header-background;
   margin:0;
   padding:0;
   overflow-x: hidden;
+  margin-bottom: 175px;
 }
 
 a{
@@ -155,7 +161,9 @@ article {
 }
 
 footer {
-  position:relative;
+  bottom: 0;
+  height: 175px;
+  position:absolute;
   width: 100%;
 
   .dark{


### PR DESCRIPTION
These CSS changes make the footer sticky, on some pages such as http://24pullrequests.com/users/Gazler on a high resolution, the footer is half way up the page.

I have tested this on my Android device too and it worked fine.
