### PR TITLE
Set text-indent for logo

### DIFF
--- a/app/assets/stylesheets/site.css.scss
+++ b/app/assets/stylesheets/site.css.scss
@@ -45,6 +45,7 @@ section {
   left: 50%;
   margin-left: -$width/2;
   background: asset-url("logo.png") no-repeat bottom;
+  text-indent: -9999px;
 
   a {
     position: absolute;


### PR DESCRIPTION
Fixes the problem: 
https://www.evernote.com/shard/s7/sh/1a1ca67a-df46-4a0a-9e4f-be4ad19cbf71/8b297e9b511aa3068c6a2dcae40254a5
