### PR TITLE
Allow user to update nickname in preferences

### DIFF
--- a/app/views/dashboards/preferences.html.haml
+++ b/app/views/dashboards/preferences.html.haml
@@ -13,6 +13,8 @@
     = form.input :email, hint: t("preferences.hint.confirm_email")
   - else
     = form.input :email
+
+  = form.input :nickname
   = form.input :email_frequency, :collection => [['Never', 'none'], ['Daily', 'daily'], ['Weekly', 'weekly']], :selected => (form.object.email_frequency || 'daily')
   - if current_user.twitter_linked?
     .control-group

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -40,5 +40,15 @@ describe 'Dashboard' do
       click_on 'Save and Continue'
       user.languages.should eq ['Ruby']
     end
+
+    it 'allows the user update their nickname' do
+      user_id = user.id
+      fill_in 'user_nickname', with: 'example-nick'
+      click_on 'Save and Continue'
+
+      # have to grab the updated user information
+      user = User.find_by_id(user_id)
+      user.nickname.should eq 'example-nick'
+    end
   end
 end


### PR DESCRIPTION
When a user changes their github username, they can now update their
nickname so pull requests continue to sync.

Please review my new spec. I had to fetch a new user model to make the test work.
