### PR TITLE
Specify poltergeist version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,8 +57,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'capybara', '2.2.0'
-  gem 'poltergeist'
+  gem 'poltergeist', '~> 1.4.0'
   gem 'launchy', '2.4.2'
 
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
       httparty (>= 0.6, < 1.0)
       multi_json (~> 1.0)
     builder (3.1.4)
-    capybara (2.2.0)
+    capybara (2.1.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
@@ -60,6 +60,7 @@ GEM
       sprockets
     childprocess (0.3.9)
       ffi (~> 1.0, >= 1.0.11)
+    cliver (0.2.2)
     coderay (1.1.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -101,9 +102,6 @@ GEM
     faraday (0.8.8)
       multipart-post (~> 1.2.0)
     fastercsv (1.5.5)
-    faye-websocket (0.7.0)
-      eventmachine (>= 0.12.0)
-      websocket-driver (>= 0.3.0)
     ffi (1.9.0)
     foreman (0.63.0)
       dotenv (>= 0.7)
@@ -204,10 +202,11 @@ GEM
       multi_json (~> 1.3)
       omniauth-oauth (~> 1.0)
     pg (0.17.0)
-    poltergeist (1.1.0)
-      capybara (~> 2.0, >= 2.0.1)
-      faye-websocket (~> 0.4, >= 0.4.4)
-      http_parser.rb (~> 0.5.3)
+    poltergeist (1.4.1)
+      capybara (~> 2.1.0)
+      cliver (~> 0.2.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     polyglot (0.3.3)
     pry (0.9.12.4)
       coderay (~> 1.0)
@@ -356,7 +355,6 @@ DEPENDENCIES
   anjlab-bootstrap-rails (~> 2.3.1)
   brakeman
   bugsnag (= 1.6.3)
-  capybara (= 2.2.0)
   chai-jquery-rails
   coffee-rails
   coveralls
@@ -382,7 +380,7 @@ DEPENDENCIES
   omniauth-github
   omniauth-twitter
   pg
-  poltergeist
+  poltergeist (~> 1.4.0)
   quiet_assets
   rabl
   rack-google-analytics


### PR DESCRIPTION
This will allow poltergeist to specify the Capybara verison. Currently
tests don't pass due to poltergeist throwing a nil exception. See
https://github.com/jonleighton/poltergeist/issues/320#issuecomment-29307753.
