### PR TITLE
Moves unicorn and foreman gems to production group in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'anjlab-bootstrap-rails', '~> 2.3.1', :require => 'bootstrap-rails'
 gem 'simple_form', '3.0.0'
 gem 'rack-google-analytics'
 gem 'ffi', '1.9.0'
-gem 'csv_shaper'  
+gem 'csv_shaper'
 
 group :assets do
   gem 'sass-rails'


### PR DESCRIPTION
Unicorn is only used in production, and the Procfile that foreman uses specifies unicorn. With that in mind, I've moved the `unicorn` and `foreman` gems to a production group in the Gemfile to cut down on the bundle size/install time a bit.
