### PR TITLE
Added suggest link text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,7 +92,7 @@ en:
     suggestion:
       edit: Edit Suggestion
     suggest: There are no projects for that language yet, why not %{suggest_link}?
-    suggest_link_text: suggesest one
+    suggest_link_text: suggest one
     new:
       title: Suggest a Project
       info: One of the ways we encourage participation in the open source community is by letting users know what popular projects might be worth contributing to. We've selected our favorites, but we're always open to suggestions. Have some ideas? Share them below!


### PR DESCRIPTION
Right now the text on the page says 

```
There are no projects for that language yet, why not Suggest Link Text
```

This should fix that.

I'm really not sure what tests should be added for this change. Could you please provide more information about that?
