### PR TITLE
Fix typo in API documentation.

### DIFF
--- a/app/views/static/api.html.haml
+++ b/app/views/static/api.html.haml
@@ -120,7 +120,7 @@
 
 %pre
   :plain
-    $ curl http://24pullrequests.com/users/1.json
+    $ curl http://24pullrequests.com/users/andrew.json
 
     {
       "id":1,


### PR DESCRIPTION
The API documentation gave the wrong URL for specific user information.

Sorry for pull request spam, I specified the `id` instead of the `nickname` :unamused: 
