### PR TITLE
Fix irc link

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,8 +50,8 @@ en:
     profile:
       title: Build your profile
       description: Contributing to open source projects is also a great way to build your profile in the community and improve your CV.
-    join_the_chat: Join the chat on IRC, #%{link_to_chat}, at freenode.
       getting_started: It's really easy to get started. Even small contributions can be really valuable to a project.
+    join_the_chat: "Join the chat on IRC, #%{link_to_chat}, at freenode."
 
   information:
     title: "24 Pull Requests %{year} is upon us"


### PR DESCRIPTION
On the site currently, this link just stops at the hash. This translation needed to be wrapped in double quotes in order to interpolate the link.

Thought it best to isolate this as a separate commit because it wasn't a grammatical issue.
