### PR TITLE
Fix link in English locale.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,7 @@ en:
       title: Build your profile
       description: Contributing to open source projects is also a great way to build your profile in the community and improve your CV.
       getting_started: It's really easy to get started, even small contributions can be really valuable to a project.
-    join_the_chat: Join the chat on IRC, #%{link_to_chat}, at freenode.
+    join_the_chat: "Join the chat on IRC, #%{link_to_chat}, at freenode."
 
   information:
     title: "24 Pull Requests %{year} is upon us"


### PR DESCRIPTION
On the site currently, this text stops after the hash. In order for
the link to be interpolated, this string must be wrapped in quotes.
