### PR TITLE
Correctly sets the date on a new gift when one is provided.

### DIFF
--- a/app/controllers/gifts_controller.rb
+++ b/app/controllers/gifts_controller.rb
@@ -11,7 +11,7 @@ class GiftsController < ApplicationController
     gift_form = GiftForm.new(:gift           => current_user.new_gift,
                              :pull_requests  => current_user.unspent_pull_requests,
                              :giftable_dates => Gift.giftable_dates,
-                             :date => params.permit(:date))
+                             :date => params['date'])
 
     render :new, :locals => { :gift_form => gift_form }
   end

--- a/spec/controllers/gifts_controller_spec.rb
+++ b/spec/controllers/gifts_controller_spec.rb
@@ -4,12 +4,25 @@ describe GiftsController do
   let(:user) { create(:user) }
   let(:gift) { create(:gift, :user => user) }
 
+  before do
+    session[:user_id] = user.id
+  end
+
+
   describe 'DELETE destroy' do
     it "removes the gift" do
-      session[:user_id] = user.id
       delete :destroy, :id => gift.date
 
       Gift.find_by(id: gift.id).should be_nil
+    end
+  end
+
+  describe 'GET new' do
+    render_views
+
+    it "should pre-fill the date when one is passed" do
+      get :new, :date => '2013-12-03'
+      expect(response.body).to match /<option selected="selected" value="2013-12-03">/
     end
   end
 end


### PR DESCRIPTION
When creating a code gift from the calendar screen, the date select is not pre-filled. See screenshot:

![24 pull requests 2013-12-01 22-34-00](https://f.cloud.github.com/assets/298309/1652139/0414c0b6-5b03-11e3-8682-ea99974d8f13.jpg)

This PR fixes the bug and adds a test to the gift controller spec to cover it.
