### PR TITLE
Gets CoderWall badge titles displaying properly.

### DIFF
--- a/vendor/assets/javascripts/coderwall.js
+++ b/vendor/assets/javascripts/coderwall.js
@@ -85,7 +85,7 @@
       self = this;
       badgeSize = self.options.badge_size;
       compileList = function(badge, badgeObj) {
-        return '<li class="box-badge"><div class="badge-icon' + (badgeObj.count > 1 ? ' show-count' : '') + '" data-count="' + badgeObj.count + '"><img width="' + badgeSize + '" height="' + badgeSize + '" alt="' + badge + '" data-title="' + badgeObj.description + '" src="' + badgeObj.badge + '"></div><div class="badge-name">' + badge + '</div></li>';
+        return '<li class="box-badge"><div class="badge-icon' + (badgeObj.count > 1 ? ' show-count' : '') + '" data-count="' + badgeObj.count + '"><img width="' + badgeSize + '" height="' + badgeSize + '" alt="' + badge + '" title="' + badgeObj.description + '" src="' + badgeObj.badge + '"></div><div class="badge-name">' + badge + '</div></li>';
       };
       teamBadgesList = '<ul id="team_box">';
       for (badge in teamBadges) {


### PR DESCRIPTION
On a user's profile, the CoderWall badges have a `data-title` attribute containing the description that doesn't do anything. I removed the `data-` prefix so that we get a tooltip on hover. Much nicer.
