### PR TITLE
Paginate projects filtered by language

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     httpauth (0.2.0)
-    i18n (0.6.6)
+    i18n (0.6.8)
     jquery-rails (3.0.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)

--- a/app/assets/javascripts/projects.js.coffee
+++ b/app/assets/javascripts/projects.js.coffee
@@ -7,6 +7,7 @@ $ ->
     clicked_language = $(this).data().language
 
     unless clicked_language?
+      fetchProjects()
       resetLanguage()
       return false
 
@@ -27,22 +28,21 @@ $ ->
         .parent('li')
         .removeClass('disabled')
 
-      $('#projects').quicksand $(projects).find(".#{languages.join(', .')}"), duration: 0, ->
-        resetMoreButton()
+      filterProjects(languages.join(','))
     return false
 
-  resetMoreButton = ->
-    if $('#projects .project:visible').length == 0
-      $('#noprojects').show()
-      $('#someprojects').hide()
-    else
-      $('#noprojects').hide()
-      $('#someprojects').show()
-    return false
+  fetchProjects = ->
+    $.ajax
+      url: '/projects'
+      dataType: 'script'
+
+  filterProjects = (languages) ->
+    $.ajax
+      url: '/projects/filter?languages='+languages
+      dataType: 'script'
 
   resetLanguage = ->
-    $('#languages li').removeClass('disabled')
-    $('#projects').html(projects.find('.project'))
-    projects = $('#projects').clone()
-    $('#projects').css('height', 'auto')
-    resetMoreButton()
+      $('#languages li').removeClass('disabled')
+      $('#projects').html(projects.find('.span12'))
+      projects = $('#projects').clone()
+      $('#projects').css('height', 'auto')

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,9 +1,10 @@
 class ProjectsController < ApplicationController
-  before_action :ensure_logged_in, except: [ :index ]
+  before_action :ensure_logged_in, except: [ :index, :filter ]
   before_action :set_project, only: [ :edit, :update, :destroy ]
 
   respond_to :html
-  respond_to :json, :js, :only => :index
+  respond_to :json, only: :index
+  respond_to :js, only: [:index, :filter]
 
   def index
     @projects = Project.active.order(:name).page params[:page]
@@ -57,6 +58,12 @@ class ProjectsController < ApplicationController
     redirect_to :back, notice: message
   end
 
+  def filter
+    @projects = Project.active.order(:name).page params[:page]
+    @projects = @projects.by_languages(languages) if languages
+    respond_with @projects
+  end
+
   protected
 
   def project_params
@@ -69,6 +76,10 @@ class ProjectsController < ApplicationController
 
   def language
     params[:language]
+  end
+
+  def languages
+    params[:languages].split(',')
   end
 
   def github_url

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -31,6 +31,7 @@ class Project < ActiveRecord::Base
 
   scope :not_owner, lambda {|user| where("github_url" != "github.com/#{user}/") }
   scope :by_language, ->(language) { where("lower(main_language) =?", language.downcase) }
+  scope :by_languages, ->(languages) { where("lower(main_language) IN (?)", languages.map(&:downcase)) }
   scope :active, -> { where(inactive: [ false, nil ]) }
 
   paginates_per 20

--- a/app/views/languages/projects.js.haml
+++ b/app/views/languages/projects.js.haml
@@ -1,0 +1,15 @@
+:plain
+  (function($projects) {
+    var $new = $("#{escape_javascript(render(@projects))}");
+
+    $projects.find('.span12')
+      .html($new)
+
+    $(".more")
+      .replaceWith(
+        "#{escape_javascript(link_to_next_page @projects,
+                                               t('more'),
+                                               remote: true,
+                                               class: 'btn btn-success more')}"
+      );
+  })($("#projects"));

--- a/app/views/projects/filter.js.haml
+++ b/app/views/projects/filter.js.haml
@@ -1,0 +1,23 @@
+- if @projects.any?
+  :plain
+    (function($projects) {
+      var $new = $("#{escape_javascript(render(@projects))}");
+
+      $projects.find('.span12')['#{params[:page].blank? ? "html" : "append"}']($new)
+
+      $('#someprojects').find('.span12')
+        .html(
+          "#{escape_javascript(link_to_next_page @projects,
+                                                 t('more'),
+                                                 remote: true,
+                                                 params: {languages: params[:languages]},
+                                                 class: 'btn btn-success more')}"
+        );
+    })($("#projects"));
+    $('#noprojects').hide()
+    $('#someprojects').show()
+- else
+  :plain
+    $('#projects').find('.span12').empty()
+    $('#noprojects').show()
+    $('#someprojects').hide()

--- a/app/views/projects/index.js.haml
+++ b/app/views/projects/index.js.haml
@@ -1,15 +1,17 @@
 :plain
   (function($projects) {
-    var $new = $("#{escape_javascript(render(@projects))}").find("a[rel=tooltip]").tooltip().end();
+    var $new = $("#{escape_javascript(render(@projects))}");
 
     $projects.find('.span12')
           .append($new)
 
-    $projects.parent().find(".more")
-          .replaceWith(
+    $('#someprojects').find('.span12')
+          .html(
             "#{escape_javascript(link_to_next_page @projects,
                                                    t('more'),
                                                    remote: true,
                                                    class: 'btn btn-success more')}"
           );
   })($("#projects"));
+  $('#noprojects').hide()
+  $('#someprojects').show()

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Tfpullrequests::Application.routes.draw do
 
   resources :projects, :only => [:index, :new, :create, :edit, :update, :destroy] do
     collection do
+      get :filter
       post :claim
     end
   end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -70,7 +70,7 @@ describe 'Projects' do
         first(:link, "Java").click
 
         within '#projects' do
-          page.should_not have_css('.ruby')
+          page.should have_no_css('.ruby')
           page.should have_css('.java')
         end
       end


### PR DESCRIPTION
Projects filtered by language are populated and paginated by javascript ajax requests. A few thoughts. This will increase server requests slightly, compared to the previous client-side version. However, if the number of projects on the site becomes very large this method will scale more nicely.
