### PR TITLE
Fix language filtering for names with symbols and spaces

### DIFF
--- a/app/assets/javascripts/projects.js.coffee
+++ b/app/assets/javascripts/projects.js.coffee
@@ -24,7 +24,7 @@ $ ->
     else
       $('#languages li')
         .addClass('disabled')
-        .find($.map(languages, (l) -> "a[data-language=#{l}]").join(','))
+        .find($.map(languages, (l) -> "a[data-language='#{l}']").join(','))
         .parent('li')
         .removeClass('disabled')
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 module ApplicationHelper
+  def escape_language(lang)
+    url_encode(lang.downcase) if lang
+  end
+
   def parameterize_language(lang)
     if lang
       lang.gsub(/\+/, 'p')
@@ -9,12 +13,12 @@ module ApplicationHelper
 
   def language_link(language, label=nil)
     language = if language.respond_to? :map
-      language.map &method(:parameterize_language)
+      language.map &method(:escape_language)
     else
-      parameterize_language language
+      escape_language language
     end
     label = label || [language].flatten.join(', ')
-    link_to label, '#', :data => {:language => language}
+    link_to label, '#', data: {language: language}
   end
 
   def gravatar_url(digest='', size = '80')

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -18,19 +18,19 @@ describe ApplicationHelper do
 
   describe '#language_link' do
     it 'returns a link for a language' do
-      helper.language_link('C#').should eql('<a data-language="csharp" href="#">csharp</a>')
+      helper.language_link('C#').should eql('<a data-language="c%23" href="#">c%23</a>')
     end
 
     it 'returns a link with a label' do
-      helper.language_link('C#', 'Foobar').should eql('<a data-language="csharp" href="#">Foobar</a>')
+      helper.language_link('C#', 'Foobar').should eql('<a data-language="c%23" href="#">Foobar</a>')
     end
 
     it 'returns a link for multiple languages' do
-      helper.language_link(['C#', 'Ruby'], 'Foobar').should eql('<a data-language="[&quot;csharp&quot;,&quot;ruby&quot;]" href="#">Foobar</a>')
+      helper.language_link(['C#', 'Ruby'], 'Foobar').should eql('<a data-language="[&quot;c%23&quot;,&quot;ruby&quot;]" href="#">Foobar</a>')
     end
 
     it 'returns a link for multiple languages without a label' do
-      helper.language_link(['C#', 'Ruby']).should eql('<a data-language="[&quot;csharp&quot;,&quot;ruby&quot;]" href="#">csharp, ruby</a>')
+      helper.language_link(['C#', 'Ruby']).should eql('<a data-language="[&quot;c%23&quot;,&quot;ruby&quot;]" href="#">c%23, ruby</a>')
     end
   end
 


### PR DESCRIPTION
This should fix project filtering by language when the language has a symbol or space (i.e. C#, Emacs Lisp, ...).
