### PR TITLE
Fix duplicated recommended project since github url's are case insensitive

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -25,7 +25,7 @@ class Project < ActiveRecord::Base
 
   validates_presence_of :description, :github_url, :name, :main_language
   validates_format_of :github_url, :with => /\Ahttps?:\/\/(www\.)?github.com\/[\w-]*\/[\w\.-]*(\/)?\Z/i, :message => 'Enter the full HTTP URL.'
-  validates_uniqueness_of :github_url, :message => "Project has already been suggested."
+  validates_uniqueness_of :github_url, :case_sensitive => false ,:message => "Project has already been suggested."
   validates_length_of :description, :within => 20..200
   validates_inclusion_of :main_language, :in => LANGUAGES, :message => 'must be a programming language'
 


### PR DESCRIPTION
Currently there are several repeated entries due to the fact that Github projects urls are case Insensitive, for instance: 

![screen shot 2013-12-05 at 8 29 30 am](https://f.cloud.github.com/assets/845590/1682768/e3ff727e-5db1-11e3-82ef-8fac63df31a1.png)

This fix prevents more duplication, but a manual cleanup will be necessary to clear the records that are already duplicated.
