### PR TITLE
Adds email address to profile pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'simple_form', '3.0.0'
 gem 'rack-google-analytics'
 gem 'ffi', '1.9.0'
 gem 'csv_shaper'
+gem 'obfuscatejs'
 
 group :assets do
   gem 'sass-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,9 @@ GEM
       jwt (~> 0.1.4)
       multi_json (~> 1.0)
       rack (~> 1.2)
+    obfuscatejs (1.1.3)
+      jquery-rails
+      rails (>= 3.2.11)
     octokit (2.6.2)
       sawyer (~> 0.5.1)
     omniauth (1.1.4)
@@ -375,6 +378,7 @@ DEPENDENCIES
   launchy (= 2.4.2)
   memcachier
   newrelic_rpm
+  obfuscatejs
   octokit
   omniauth
   omniauth-github

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -12,11 +12,14 @@
       .span4
         = github_button @user.nickname
       - if @user.twitter_nickname.present?
-        .span6
+        .span3
           %a{:href => "https://twitter.com/#{@user.twitter_nickname}", :class => 'twitter-follow-button'}
             =t("follow_user", twitter: @user.twitter_nickname)
           :javascript
             !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");
+      - if @user.email.present?
+        .span3
+          = obfuscate_email(@user.email, "Email @#{@user.nickname}")
 
     - if @user.skills.any?
       %h4


### PR DESCRIPTION
Uses the `obfuscatejs` gem to add the user's email address to profile pages. Adds public email address to profile page for easy contact access, while obfuscating it so that spambots can't read it.
