### PR TITLE
Fix broken user profile link bug

### DIFF
--- a/app/views/pull_requests/_pull_request.html.haml
+++ b/app/views/pull_requests/_pull_request.html.haml
@@ -1,7 +1,7 @@
 = cache pull_request do
   .pull_request.row-fluid.clearfix{:class => parameterize_language(pull_request.language)}
     .span12
-      = link_to image_tag(gravatar_url(pull_request.user.gravatar_id), :width => 80, :height => 80, :alt => pull_request.user.nickname), pull_request.user.nickname, :rel => 'tooltip', :data => { :original_title => pull_request.user.nickname }, :class => 'image'
+      = link_to image_tag(gravatar_url(pull_request.user.gravatar_id), :width => 80, :height => 80, :alt => pull_request.user.nickname), user_path(pull_request.user.nickname), :rel => 'tooltip', :data => { :original_title => pull_request.user.nickname }, :class => 'image'
       %h4
         = link_to pull_request.title, pull_request.issue_url, :target => :blank
         %span.meta


### PR DESCRIPTION
If you go to an organisation's 24PRs page (e.g. http://24pullrequests.com/organisations/Softwire) and click on a users picture, in the list below (not the members list), it takes you to 24pullrequests.com/organisations/USERNAME, which is clearly wrong, and will give you a 404.

This patch fixes that by using user_path instead, to get the full URL for the user nick, as in _user.html.haml.

(I should note that I've done this whole change entirely through the github interface, because I'm on windows with x64 Ruby atm and getting all the Ruby deps building properly to run 24PRs locally is near impossible, so I haven't tested this _at all_. Still, it's so small it can't possibly fail, right?)
