### PR TITLE
Cache gems and assets in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,7 @@ script:
   - RAILS_ENV=test POLTERGEIST=true bundle exec rake --trace db:migrate spec konacha:run
 before_script:
   - psql -c 'create database tfpullrequests_test' -U postgres
+cache:
+  bundler: true
+  directories:
+    - tmp/cache/assets/test/sprockets


### PR DESCRIPTION
Should speed up the test suite a fair amount.

As outlined here: http://about.travis-ci.org/blog/2013-12-05-speed-up-your-builds-cache-your-dependencies/
