### PR TITLE
Moved language autocomplete to bootstrap as was deleted from projects

### DIFF
--- a/app/assets/javascripts/bootstrap.js.coffee
+++ b/app/assets/javascripts/bootstrap.js.coffee
@@ -8,3 +8,15 @@ jQuery ->
   $("#presents a").click (e) ->
     e.preventDefault()
     $(this).tab "show"
+
+
+  languageAutocomplete = ->
+    return false if !$("[data-provide=typeahead]").length
+
+    projectLanguages = $("[data-provide=typeahead]").data "source"
+
+    $("[data-provide=typeahead]").typeahead
+      name: $(this).attr "name"
+      local: projectLanguages
+
+  languageAutocomplete()


### PR DESCRIPTION
@despo I've pulled the autocomplete into Bootstrap coffee because the Projects coffee file was deleted and the language autocomplete wouldn't work without this (as typeahead is now a separate component).
