### PR TITLE
Direct link to The Changelog instead of 301

### DIFF
--- a/app/views/static/contributing.html.haml
+++ b/app/views/static/contributing.html.haml
@@ -37,7 +37,7 @@
 %ul
   %li= link_to 'Using Pull Requests', 'https://help.github.com/articles/using-pull-requests'
   %li= link_to 'A quick guide to pull requests', 'http://beust.com/weblog/2010/09/15/a-quick-guide-to-pull-requests/'
-  %li= link_to 'You (yes, you!) should contribute to open source', 'http://thechangelog.com/post/5367356233/you-yes-you-should-contribute-to-open-source'
+  %li= link_to 'You (yes, you!) should contribute to open source', 'http://thechangelog.com/you-yes-you-should-contribute-to-open-source/'
   %li= link_to 'How to contribute a patch to a GitHub hosted Open Source project', 'http://www.hanselman.com/blog/GetInvolvedInOpenSourceTodayHowToContributeAPatchToAGitHubHostedOpenSourceProjectLikeCode52.aspx'
 
 %h3 Other ways to find projects


### PR DESCRIPTION
The Changelog has moved from Tumblr to [a WordPress blog](http://thechangelog.com/relaunched-member-supported/). Just updates the link from the one on Tumblr to the live one now.
