### PR TITLE
Dont send confirmation mail if email is blank

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -129,15 +129,6 @@ class User < ActiveRecord::Base
     end
   end
 
-  def check_email_changed
-    return unless self.email_changed?
-
-    self.generate_confirmation_token
-    self.confirmed_at = nil
-
-    ConfirmationMailer.confirmation(self).deliver
-  end
-
   def send_notification_email
     return unless confirmed?
     if send_daily?
@@ -219,6 +210,15 @@ class User < ActiveRecord::Base
   end
 
   private
+
+  def check_email_changed
+    return unless self.email_changed? && self.email.present?
+
+    self.generate_confirmation_token
+    self.confirmed_at = nil
+
+    ConfirmationMailer.confirmation(self).deliver
+  end
 
   def pull_request_downloader(access_token = token)
     Rails.application.config.pull_request_downloader.call(nickname, access_token)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,10 +11,42 @@ describe User do
 
   describe 'callbacks' do
     describe 'before_save' do
-      it 'checks if the email address changed' do
-        new_user = build :user
-        new_user.should_receive(:check_email_changed)
-        new_user.save
+      describe '.check_email_changed' do
+        subject { build :user }
+
+        it 'is called if email changed' do
+          subject.should_receive(:check_email_changed)
+          subject.save
+        end
+
+        context 'email is present' do
+          it 'generates a confirmation token' do
+            subject.should_receive(:generate_confirmation_token)
+            subject.save
+          end
+
+          it 'sends a confirmation email' do
+            ConfirmationMailer.should_receive(:confirmation).and_return double("ConfirmationMailer", deliver: true)
+            subject.save
+          end
+        end
+
+        context 'email is blank' do
+          before do
+            subject.save
+            subject.email = nil
+          end
+
+          it 'doesnt generate a confirmation token' do
+            subject.should_not_receive(:generate_confirmation_token)
+            subject.save
+          end
+
+          it 'doesnt send a confirmation email' do
+            ConfirmationMailer.should_not_receive(:confirmation)
+            subject.save
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This fixes issue #314

As stated by bob-p before_save hooks are run after the after_validation hook. However, the email validation also allows for empty email addresses. The check_email_changed method now only acts if the email did change and is present, if someone clears the email address the method just returns.

Also made the #check_email_changed method private, it isn't used anywhere directly.
