### PR TITLE
fixed translation key selector for home page - contributing_path

### DIFF
--- a/app/views/static/homepage.html.haml
+++ b/app/views/static/homepage.html.haml
@@ -38,7 +38,7 @@
     %hr
     %p=t("homepage.involved.description")
     %p
-      =t("homepage.involved.special_page", contributing_path: link_to(t("contributing_path"), contributing_path)).html_safe
+      =t("homepage.involved.special_page", contributing_path: link_to(t("homepage.involved.contributing_path"), contributing_path)).html_safe
       =t("homepage.involved.take_a_look")
 
     %h4=t("homepage.profile.title")


### PR DESCRIPTION
This was causing a translation not found error (title of the link) resulting in displaying of "Contributing Path" instead of special page (which I assume was originally intended looking at history of this file).
