### PR TITLE
Change tooltip to reflect correct Continuous Sync badge condition

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,7 @@ en:
       title: Earn Coderwall badges
       description: We've teamed up with coderwall and created some kickass badges to unlock for participating.
       involved_link: 'Participant - Get involved, send at least one pull request before Christmas'
-      amazing: "Continuous Sync - You're an open source machine, send 24 pull requests before Christmas"
+      amazing: "Continuous Sync - You're an open source machine, send 24 pull requests during December, before Christmas"
     involved:
       title: Get involved
       description: "There are loads of ways to get involved in an open source project: improving documentation, helping fix existing issues and bugs, improving code quality and test coverage, or adding missing features."


### PR DESCRIPTION
I asked a question a week or ago clarifying the condition for receiving the Continuous Sync badge on Coderwall. I received a response from Andrew (https://twitter.com/teabass/status/410085515829202944) that said the 24 pull requests must be before Christmas. The way this is currently worded suggests to me that you'd also get Christmas and the remaining days of December to finish your pull requests. This PR changes the wording to make this consistent with my understanding for the English locale.
