### PR TITLE
Fix checkbox css on preferences

### DIFF
--- a/app/assets/stylesheets/dashboard.css.scss
+++ b/app/assets/stylesheets/dashboard.css.scss
@@ -3,8 +3,13 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 #skills {
-  .form-group {
+  .col-sm-3 {
     text-align: right;
+    margin-bottom: 15px;
+
+    .control-label {
+	float: right;
+    }
   }
   label {
     padding: 0

--- a/app/views/dashboards/preferences.html.haml
+++ b/app/views/dashboards/preferences.html.haml
@@ -37,11 +37,11 @@
   #skills.clearfix
     = form.simple_fields_for :skills, Project::LANGUAGES.map{|l| Skill.new(:language => l)} do |skill_form|
       - language = skill_form.object.language
-      .form-group.col-sm-3
-        %label.control-label{:for => language}= language
-        .controls
-          = skill_form.check_box :language, {:id => language, :checked => current_user.skills.map(&:language).include?(language)}, language
-
+      .col-sm-3
+        .col-sm-10
+          .controls
+            = skill_form.check_box :language, {:id => language, :checked => current_user.skills.map(&:language).include?(language)}, language
+          %label.control-label{:for => language}= language
   .form-group
     .col-md-offset-3.col-sm-10
       = form.button :submit, t("preferences.save_and_continue")


### PR DESCRIPTION
`margin-left` and `margin-right` was on the top of the checkboxes so they were not reachable.
This changes the markup a little bit, but the final result is almost the same as the live one, without using margins to they dont block the checkboxes.

[fixes #554]
