### PR TITLE
Update gift dropdown after pull requests sync

### DIFF
--- a/app/assets/javascripts/dashboard.js.coffee
+++ b/app/assets/javascripts/dashboard.js.coffee
@@ -10,4 +10,11 @@ $ ->
 
       success: (data) ->
         $('#pull-requests').html(data)
+        dropdown = $('#gift_pull_request_id')
+        dropdown.empty()
+        $('.pull_request[data-gifted="not_gifted"]').each((index, element) ->
+          $element = $(element);
+          option = $('<option/>').attr('value', $element.data('id')).text($element.data('dropdown-text'))
+          dropdown.prepend(option)
+        )
         $("#spinner, #search_button").toggle()

--- a/app/helpers/pull_request_helper.rb
+++ b/app/helpers/pull_request_helper.rb
@@ -4,4 +4,8 @@ module PullRequestHelper
     return pull_request_count_for_language if @language
     PullRequest.year(Time.now.year).count
   end
+
+  def gift_dropdown_text pull_request
+    "#{pull_request.gifted_state.to_s.humanize}: #{pull_request.repo_name} - #{pull_request.title}"
+  end
 end

--- a/app/models/gift_form.rb
+++ b/app/models/gift_form.rb
@@ -1,4 +1,5 @@
 class GiftForm
+  include PullRequestHelper
   attr_reader :gift
 
   def initialize(args={})
@@ -10,7 +11,7 @@ class GiftForm
 
   def pull_requests_for_select
     @pull_requests.sort{ |pr1, pr2| pr2.gifted_state <=> pr1.gifted_state }.map{ |pr|
-      ["#{pr.gifted_state.to_s.humanize}: #{pr.repo_name} - #{pr.title}", pr.to_param]
+      [gift_dropdown_text(pr), pr.to_param]
     }
   end
 

--- a/app/views/pull_requests/_pull_request.html.haml
+++ b/app/views/pull_requests/_pull_request.html.haml
@@ -1,5 +1,5 @@
 = cache pull_request do
-  .pull_request{:class => parameterize_language(pull_request.language)}
+  .pull_request{:class => parameterize_language(pull_request.language), :data => {:gifted => pull_request.gifted_state, :dropdown_text => gift_dropdown_text(pull_request), :id => pull_request.to_param}}
     = link_to image_tag(gravatar_url(pull_request.user.gravatar_id), :width => 80, :height => 80, :alt => pull_request.user.nickname), user_path(pull_request.user.nickname), :rel => 'tooltip', :data => { :original_title => pull_request.user.nickname }, :class => 'image'
     %h4
       = link_to pull_request.title, pull_request.issue_url, :target => :blank


### PR DESCRIPTION
This is a fix for issue #567 (by adding some data-attributes to the .pull_request elements and using that data to populate the dropdown after a sync) - but I'm not happy with it!

The big problem with it is the #TODO in the dashboard_spec.rb: there's a sleep in there, because I can't seem to convince Capybara to wait for the spinner to disappear. I'm pretty rusty with Rails, though, so I'm sure I'm just missing something obvious - can anyone point me in the right direction? I'll very happily update this PR if so.

As the comment says, I've tried `page.find('#spinner', visible: false)`, but that doesn't appear to introduce a wait at all. I thought this might be because the find was executing before the spinner had been shown, but searching for visible:true followed by visible:false didn't seem to wait, either. I've tried various other things (e.g. `page.should have_selector('#spinner', visible:false)`, `page.find('#spinner').should_not be_visible`) but all without success.

As I say, any pointers gratefully received!

Thanks,
Rowan
