### PR TITLE
Home page N+1 queries caused by organizations

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -4,7 +4,7 @@ class OrganisationsController < ApplicationController
   respond_to :js, only: :index
 
   def index
-    @organisations = Organisation.order_by_pull_requests.page(params[:page])
+    @organisations = Organisation.with_user_counts.order_by_pull_requests.page(params[:page])
     respond_with @organisations
   end
 

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -2,7 +2,7 @@ class StaticController < ApplicationController
   def homepage
     @projects = Project.includes(:labels).active.limit(200).sample(14)
     @users = User.users_with_pull_request_counts(current_year).limit(200).sample(45)
-    @orgs = Organisation.order_by_pull_requests.limit(200).sample(45)
+    @orgs = Organisation.with_user_counts.order_by_pull_requests.limit(200).sample(45)
     @pull_requests = PullRequest.year(current_year).order('created_at desc').limit(5)
     @quote = Quote.random
   end

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -5,7 +5,9 @@ module OrganisationHelper
   end
 
   def organisation_tooltip organisation
-    user_count = organisation.users.count
+    #when organizations are fetched without using "with_user_counts" (eg. @user.organizations), we would not have 'users_count'
+    user_count = organisation.respond_to?(:users_count) ? organisation.users_count : organisation.users.count
+    
     member = "member".pluralize(user_count)
     "#{organisation.login} - #{user_count} #{member} - #{organisation.pull_request_count} pull requests"
   end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -15,6 +15,10 @@ class Organisation < ActiveRecord::Base
 
       where(:login => response.login).first_or_create(params)
     end
+
+    def with_user_counts
+      joins(:users).select("organisations.*, COUNT(users.id) as users_count").group("organisations.id")
+    end
   end
 
   def active_languages

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -15,6 +15,14 @@ describe Organisation do
     ordered_organisations.last.pull_request_count.should eq(2)
   end
 
+  it "with_user_counts" do
+    setup_organizations_with_users
+
+    organisations_with_user_counts = Organisation.with_user_counts
+    organisations_with_user_counts.first.users_count.should eq(3)
+    organisations_with_user_counts.last.users_count.should eq(1)
+  end
+
   def setup_pull_request_data
     most_pr_user = create(:user)
     3.times { create :pull_request, user: most_pr_user }
@@ -29,6 +37,15 @@ describe Organisation do
     create :organisation, login: '24pullrequsts', users: [ some_pr_user ]
     create :organisation, login: 'kobol',  users: [ most_pr_user, some_pr_user, low_pr_user ]
     create :organisation, login: 'caprica', users: [ most_pr_user, some_pr_user ]
+  end
+
+  def setup_organizations_with_users
+    user_one = create(:user)
+    user_two = create(:user)
+    user_three = create(:user)
+
+    create :organisation, login: 'pugnation', users: [ user_one, user_two, user_three ]
+    create :organisation, login: 'caprica', users: [ user_three ]
   end
 
 end


### PR DESCRIPTION
Prevented N+1 queries in home page due to fetching of organizations users name.

Spec added as well.
