### PR TITLE
Fix capitals in API and GitHub

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -27,7 +27,7 @@ class Project < ActiveRecord::Base
   belongs_to :submitted_by, class_name: "User", foreign_key: :user_id
 
   validates_presence_of :description, :github_url, :name, :main_language
-  validates_format_of :github_url, :with => /\Ahttps?:\/\/(www\.)?github.com\/[\w-]*\/[\w\.-]*(\/)?\Z/i, :message => 'Enter the valid github URL.'
+  validates_format_of :github_url, :with => /\Ahttps?:\/\/(www\.)?github.com\/[\w-]*\/[\w\.-]*(\/)?\Z/i, :message => 'Enter a valid GitHub URL.'
   validates_uniqueness_of :github_url, :case_sensitive => false ,:message => "Project has already been suggested."
   validates_length_of :description, :within => 20..200
   validates_inclusion_of :main_language, :in => LANGUAGES, :message => 'must be a programming language'

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -47,7 +47,7 @@ class PullRequest  < ActiveRecord::Base
       user.twitter.update(I18n.t 'pull_request.twitter_message', :issue_url => issue_url) if user && user.twitter_linked?
     rescue => e
       puts e.inspect
-      puts 'likely a Twitter api error occurred'
+      puts 'likely a Twitter API error occurred'
     end
   end
 

--- a/app/models/pull_request_downloader.rb
+++ b/app/models/pull_request_downloader.rb
@@ -30,7 +30,7 @@ class PullRequestDownloader
       end
     rescue => e
       puts e.inspect
-      puts 'Pull requests: likely a Github api error occurred'
+      puts 'Pull requests: likely a GitHub API error occurred'
       []
     end
   end
@@ -43,7 +43,7 @@ class PullRequestDownloader
       end
     rescue e
       puts e.inspect
-      puts 'Organisation error: likely a Github api error occurred'
+      puts 'Organisation error: likely a GitHub API error occurred'
       []
     end
   end


### PR DESCRIPTION
Also slight change in error message from

> Enter the valid GitHub URL

to 

> Enter a valid GitHub URL

Latter feels a little smoother.
