### PR TITLE
Added short sleep to improve reliable spec run

### DIFF
--- a/spec/requests/organisations_spec.rb
+++ b/spec/requests/organisations_spec.rb
@@ -12,6 +12,7 @@ describe 'Organisations' do
 
   it "viewing an organization" do
     organisation = create(:organisation)
+    sleep 0.05
     visit organisation_path(organisation)
 
     should have_content "0 pull requests submitted by members"


### PR DESCRIPTION
Added short sleep (0.05 seconds) to improve reliable spec run.
Here is an example Travis run with the problem: https://travis-ci.org/andrew/24pullrequests/builds/15818416
