### PR TITLE
Add test proving filters apply to projects pagination

### DIFF
--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -65,6 +65,16 @@ describe 'Projects' do
           page.should have_css('.java')
         end
       end
+
+      it 'should retain selected filters when requesting more pages' do
+        30.times do |i|
+          create :project, name: "Ruby project #{i}", main_language: 'Ruby'
+        end
+        visit projects_path
+
+        click_on 'More'
+        all('#projects project').each{|project| project .should have_css('ruby') }
+      end
     end
   end
 


### PR DESCRIPTION
Hi,

The current live site doesn't seem to honour the filters on the projects page when fetching later pages. It looks like this was reported in #564 and fixed in #565 (but hasn't yet been deployed). It took me a little moment to find that out, though - it might have been a little easier to determine if it'd already been fixed if it had been documented in tests.

This PR adds some tests to complement the fix in #565.

Thanks,
Rowan
