### PR TITLE
Simplified contributor list on About page

### DIFF
--- a/app/views/static/_contributors.html.haml
+++ b/app/views/static/_contributors.html.haml
@@ -1,19 +1,11 @@
 %section
   %h3=t("contributors.title")
   .row
-    - users.each_slice(4) do |row|
+    - users.each_slice(6) do |row|
       %ul.thumbnails.clearfix
         - row.each do |user|
-          %li.collaborator.col-md-3
+          %li.collaborator.col-md-2
             .thumbnail
-              = link_to image_tag(gravatar_url(user.gravatar_id, 200), :width => 200, :alt => user.nickname).html_safe, user.github_profile, target: '_blank'
+              = link_to image_tag(gravatar_url(user.gravatar_id, 200), :width => 200, :height => 200, :alt => user.nickname).html_safe, user
               .caption
-                %p
-                  %strong= link_to "@#{user.nickname}", user.github_profile, target: '_blank'
-                %p
-                  = github_button user.nickname
-                - if user.twitter_linked?
-                  %a{:href => "https://twitter.com/#{user.twitter_nickname}", :class => 'twitter-follow-button'}
-                    =t("follow_user", twitter: user.twitter_nickname)
-                  :javascript
-                    !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");
+                %strong= link_to "@#{user.nickname}", user


### PR DESCRIPTION
![screen shot 2014-10-25 at 10 18 52 am](https://cloud.githubusercontent.com/assets/1060/4779340/00a59398-5c28-11e4-966e-7882ecd8f7f8.png)

All those iframe follow badges were making the About page load very slowly, I've removed them and linked the contributors to their 24 Pull Requests profile page instead, as well as reducing the size of the avatars to fit more on each row.
