### PR TITLE
Increased 'sleep' duration to fix org spec

### DIFF
--- a/spec/requests/organisations_spec.rb
+++ b/spec/requests/organisations_spec.rb
@@ -12,7 +12,7 @@ describe 'Organisations', :type => :request do
 
   it "viewing an organization" do
     organisation = create(:organisation)
-    sleep 1
+    sleep 6
     visit organisation_path(organisation)
 
     is_expected.to have_content "0 pull requests submitted by members"


### PR DESCRIPTION
1. Ran "rake" and had 1 failed test so ran separate spec:
   - rspec ./spec/requests/organisations_spec.rb:13
   - and got: 
     - Failure/Error: visit organisation_path(organisation)
     - ActiveRecord::RecordNotFound:
     - ActiveRecord::RecordNotFound
2. Pushed it to Github and checked Travis-ci:
   - FAILED: https://travis-ci.org/jasnow/24pullrequests/builds/39044347
3. So I changed "sleep" from 1 to 6 seconds on my machine. (minimum change)
4. Repeated step 1 and it passed so repeated step 2.
   - PASSED: https://travis-ci.org/jasnow/24pullrequests/builds/39045047
