### PR TITLE
Setup PullReview integration with CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development, :test, :cucumber do
   gem 'rspec-rails'
   gem 'coveralls', require: false
   gem 'codeclimate-test-reporter', require: nil
+  gem 'pullreview-coverage', require: false
 
   gem 'rspec-its'
   gem 'rspec-collection_matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,6 +225,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pullreview-coverage (0.0.2)
+      simplecov (>= 0.7.1, < 1.0.0)
     quiet_assets (1.0.3)
       railties (>= 3.1, < 5.0)
     rabl (0.11.4)
@@ -417,6 +419,7 @@ DEPENDENCIES
   omniauth-twitter
   pg
   poltergeist
+  pullreview-coverage
   quiet_assets
   rabl
   rack-google-analytics

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,8 @@ SimpleCov.start
 require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 
+require 'pullreview/coverage_reporter'
+PullReview::CoverageReporter.start
 
 require 'spork'
 


### PR DESCRIPTION
That will allow PullReview to retrieves test coverage reports and crunch them in order to report which modifications in a branch has been covered by tests.
