### PR TITLE
Replace 'btn-inverse' with 'btn-default' to fix display issue

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -96,7 +96,7 @@
             = link_to 'API', api_path
           %li
             .locale.dropup
-              %button.btn.btn-inverse.dropdown-toggle{ type: "button", id: "locale", "data-toggle" => "dropdown" }
+              %button.btn.btn-default.dropdown-toggle{ type: "button", id: "locale", "data-toggle" => "dropdown" }
                 =image_tag "flags/#{I18n.locale}.png", class: "flag"
                 =t("locale.#{I18n.locale}")
                 %span.caret


### PR DESCRIPTION
### What

With the exception of the root page (which is using the "homepage" layout), it seemed that all pages were using the "application" layout, which has buttons using the class `btn-inverse`. This bootstrap class made buttons difficult to read, as seen below:

Class of `btn-default`: 
![image](https://cloud.githubusercontent.com/assets/4978418/5194831/887fdd60-74e1-11e4-860d-8e2403992c0f.png)

Class of `btn-inverse`:
![image](https://cloud.githubusercontent.com/assets/4978418/5194854/c01e03a0-74e1-11e4-925a-741334c93d0f.png)
### How

I simply changed the button class used in the application layout file, which every page but the home page is using.
### Why

In addition to the improved consistency and readability, it appears that the `btn-inverse` class has been [removed from Bootstrap 3](http://getbootstrap.com/migration/), and some guides suggested [replacing it with default](http://code.divshot.com/bootstrap3_upgrader/).
