### PR TITLE
removed .row from suggested projects list to fix margin

### DIFF
--- a/app/views/dashboards/show.html.haml
+++ b/app/views/dashboards/show.html.haml
@@ -32,7 +32,7 @@
     %p
       #{t("dashboard.help_out")}:
 
-    .row#projects
+    #projects
       = render projects
 
     = link_to t("navigation.all_projects"), projects_path, :class => "btn btn-default btn-block"


### PR DESCRIPTION
Fixes the margin in user's dashboard where projects are listed.
#### before:

![24pr_before](https://cloud.githubusercontent.com/assets/1220480/5242390/d8fb13ca-7957-11e4-9f7c-65470e3fb664.png)
#### after:

![24pr_after](https://cloud.githubusercontent.com/assets/1220480/5242393/e25ac9ba-7957-11e4-9439-6e10cc653654.png)

_note margin of projects_

/cc. @muan 
