### PR TITLE
Fix floating in pull request listing

### DIFF
--- a/app/assets/stylesheets/site.css.scss
+++ b/app/assets/stylesheets/site.css.scss
@@ -403,6 +403,7 @@ footer {
   margin: 20px 0;
   padding-bottom: 20px;
   border-bottom: 1px dotted #d0d0d0;
+  overflow: hidden;
 
   &:last-child {
     border-bottom: 0;


### PR DESCRIPTION
At the moment, the PR listing looks a bit awkward:

![](https://cloud.githubusercontent.com/assets/153481/5243207/673b8488-7941-11e4-80bc-3425bf53261b.png)

This is fixed by this PR:

![](https://cloud.githubusercontent.com/assets/153481/5243213/84b81166-7941-11e4-9929-2bfdeba3e1bf.png)
