### PR TITLE
Sticky Footer

### DIFF
--- a/app/assets/stylesheets/site.css.scss
+++ b/app/assets/stylesheets/site.css.scss
@@ -13,6 +13,7 @@ body {
   height: 100%;
   font-size: 14px;
   line-height: 1.6em;
+  margin-bottom: 115px;
 }
 
 h1, h2, h3, h4, .page-title {
@@ -314,6 +315,9 @@ nav {
 
 footer {
   width: 100%;
+  position: absolute;
+  bottom: 0;
+  height: 115px;
 
   .dark {
     color: rgba(255,255,255,.2);


### PR DESCRIPTION
In the commit 57229d03f9abded12033719355045bc90b0a99ba the footer was
made sticky by making it `position: absolute; bottom: 0`

In the commit 8976cfc968d384cba7491eaa21718ce011528dcd the sticky footer
was removed.

This commit reintroduces the stickiness of the footer. The reason for
the sticky footer is on a high resolution, the footer displays half way
up the page.
