### PR TITLE
Added the CoderWall badge unlock date for EN and DE locales

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -38,7 +38,7 @@ de:
     q_n_a: Fragen & Antworten
     badges:
       title: Coderwall Badges verdienen
-      description: Zusammen mit Coderwall verteilen wir ein paar tolle Badges, die Du durchs Mitmachen verdienen kannst.
+      description: Zusammen mit Coderwall verteilen wir ein paar tolle Badges, die Du durchs Mitmachen verdienen kannst (freigeschaltet am 24. Dezember).
       involved_link: 'Participant (Teilnehmer) - Mach mit, versende mindestens einen Pull Request vor Weihnachten'
       amazing: "Continuous Sync (Kontinuierliche Synchronisation) - Du bist eine Open Source-Maschine, versende 24 Pull Requests im Dezember"
     involved:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,7 +43,7 @@ en:
     q_n_a: Questions & Answers
     badges:
       title: Earn Coderwall badges
-      description: We've teamed up with coderwall and created some kickass badges to unlock for participating.
+      description: We've teamed up with coderwall and created some kickass badges to unlock for participating (awarded December 24th).
       involved_link: 'Participant - Get involved, send at least one pull request before Christmas'
       amazing: "Continuous Sync - You're an open source machine, send 24 pull requests during December, before Christmas"
     involved:


### PR DESCRIPTION
Hi, this is a simple fix for #723 - I've added the unlock information for the two locales I'm capable of speaking :smile:

I'm open for suggestions how to transport this information in a less intrusive/landing-page-y way. :)
