### PR TITLE
Blank label fix

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -60,6 +60,7 @@ class ProjectsController < ApplicationController
 
   def filter
     @languages, @labels = languages, labels
+    @labels = [] if @labels.blank?
     @projects = ProjectSearch.new(page: params[:page], labels: @labels, languages: @languages).find.includes(:labels)
     respond_with @projects
   end


### PR DESCRIPTION
This should fix the pagination issue with blank labels on the project filter page.
