### PR TITLE
show all users uniquely in users index page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,7 @@ class UsersController < ApplicationController
   respond_to :js, only: :index
 
   def index
-    @users = User.order('pull_requests_count desc').joins(:pull_requests).where('EXTRACT(year from pull_requests.created_at) = ?', CURRENT_YEAR).page params[:page]
+    @users = User.order('pull_requests_count desc').page params[:page]
     respond_with @users
   end
 


### PR DESCRIPTION
So this page `/users` seems to have loads of duplicate users. This was caused coz of the `INNER JOIN` done to fetch users who have PRs created only in `CURRENT_YEAR`. 

My assumptions:
- Now with this PR #721 we have archived old PRs and this task have been run in Production and so `pull_requests_count` will only have the relevant PRs.
- We need to show `ALL` users in this `/users` page so that the count `user_count` correlates properly to the no. of profiles shown
- This also means we need to show users with 0 PRs (which was not happening before coz of the `INNER JOIN`. (#700).

If my assumptions are correct and if that is the expected behavior, then what I have done to implement that is I have just pulled all users, ordered them by `pull_requests_count` and paginated them. That's all.

Not sure if this is what this page needs to show... But surely the way we have duplicates and count mismatch in current thing is not right I guess? :smile: 

Lemme know what you guys think! :)
