### PR TITLE
Center aligned tweet checkbox

### DIFF
--- a/app/views/gifts/_form.html.haml
+++ b/app/views/gifts/_form.html.haml
@@ -4,9 +4,12 @@
     = form.input :date, :label => t("gifts.form.date"), :collection => gift_form.giftable_dates
 
   = form.input :pull_request_id, :label => t("gifts.form.pull_requests"), :collection => gift_form.pull_requests_for_select
-  = form.input :tweet, as: :boolean, label: false, wrapper_html: { class: "checkbox" } do
-    = form.check_box :tweet, {}, "true", "false"
-    = t("gifts.form.tweet")
+  
+  .form-group
+    .col-md-offset-2.col-sm-10
+      = form.input :tweet, as: :boolean, label: false, wrapper_html: { class: "checkbox" } do
+        = form.check_box :tweet, {}, "true", "false"
+        = t("gifts.form.tweet")
 
   .form-group
     .col-md-offset-2.col-sm-10


### PR DESCRIPTION
The tweet checkbox was not in line with the rest of the form, this pull request fixes this.

:gift: :christmas_tree: 
