### PR TITLE
Don’t look for issues on inactive projects

### DIFF
--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -10,9 +10,7 @@ task :check_for_inactive_projects => :environment do
       updated_recently = false
     end
 
-    has_active_issues = project.issues(user.nickname, user.token).any? rescue(false) unless updated_recently
-
-    unless updated_recently or has_active_issues
+    unless updated_recently
       project.deactivate!
       count = count + 1
     end


### PR DESCRIPTION
The rake task for checking for inactive projects was allowing any project with an open issue, even if it's not had a commit in 6 months.

In a future update we should switch to using @kdaigle's score checker from https://github.com/24pullrequests/24pullrequests/pull/705 and run this task on a more regular basis.

Fixes https://github.com/24pullrequests/24pullrequests/issues/697
