### PR TITLE
Remove `target="_blank"` from “Fork on GitHub” link

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -53,7 +53,7 @@
 
     .snow
 
-    %a.forkme{ :href => "https://github.com/24pullrequests/24pullrequests", :target => '_blank'}
+    %a.forkme{ :href => "https://github.com/24pullrequests/24pullrequests"}
       %img{ :src => 'https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png', :alt => 'Fork me on GitHub'}
 
     %header

--- a/app/views/layouts/homepage.html.haml
+++ b/app/views/layouts/homepage.html.haml
@@ -53,7 +53,7 @@
 
     .snow
 
-    %a.forkme{ :href => "https://github.com/24pullrequests/24pullrequests", :target => '_blank'}
+    %a.forkme{ :href => "https://github.com/24pullrequests/24pullrequests"}
       %img{ :src => 'https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png', :alt => 'Fork me on GitHub'}
 
     %header


### PR DESCRIPTION
Creating a new tab/window by default is not very user friendly. Additionally, anyone who uses 24 Pull Requests are developers, and should be able to manage a simple thing like opening in a new tab if they would like to.
