### PR TITLE
Clean up .avatar-list .username display

### DIFF
--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -223,7 +223,7 @@
     position: absolute;
     bottom: 5px;
     left: 5px;
-    right: 20px;
+    right: 34px;
     color: #fff;
     line-height: 1;
     font-size: 12px;
@@ -232,6 +232,7 @@
     overflow: hidden;
     text-align: left;
     text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .avatar-link {


### PR DESCRIPTION
Re: #782, kind of.

There are always going to be usernames too long to display. This PR truncates them, and hides `.username` for `.avatar-list` that are not also `.avatar-list-lg`.

![image](https://cloud.githubusercontent.com/assets/1153134/5374350/a5b56e9a-8099-11e4-9658-79639be1f009.png)
