### PR TITLE
Missing translation for Deactive

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,6 +94,7 @@ en:
   claim: Claim
   exempli_gratia: "e.g." # Short form of "for example"
   edit: Edit
+  deactive: Deactive
   everything: Everything
   about_us: About
   sponsors: Sponsors


### PR DESCRIPTION
Added the translation for en. Not sure how you handle adding translations for other locales.
