### PR TITLE
Added rack-canonical-host for domain redirection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'sass-rails'
 gem 'coffee-rails'
 gem 'uglifier'
 gem 'octicons-rails'
+gem 'rack-canonical-host'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,9 @@ GEM
     rabl (0.11.5)
       activesupport (>= 2.3.14)
     rack (1.5.2)
+    rack-canonical-host (0.1.0)
+      addressable
+      rack (~> 1.0)
     rack-google-analytics (1.2.0)
       actionpack
       activesupport
@@ -446,6 +449,7 @@ DEPENDENCIES
   pullreview-coverage
   quiet_assets
   rabl
+  rack-canonical-host
   rack-google-analytics
   rails (= 4.1.8)
   rails_12factor

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,8 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment',  __FILE__)
+
 use Rack::Deflater
+use Rack::CanonicalHost, ENV['CANONICAL_HOST'] if ENV['CANONICAL_HOST']
+
 run Tfpullrequests::Application


### PR DESCRIPTION
https://github.com/tylerhunt/rack-canonical-host is perfect for redirection *.herokuapp.com domains to the canonical one in #786.
