### PR TITLE
showing alert always if user has unconfirmed email

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user, :logged_in?, :current_year, :admin?
 
-  before_action :set_locale
+  before_action :set_locale, :unconfirmed_email_alert
 
   def set_locale
     I18n.locale = cookies[:locale] || I18n.default_locale
@@ -34,5 +34,9 @@ class ApplicationController < ActionController::Base
 
   def admin?
     current_user.admin?
+  end
+
+  def unconfirmed_email_alert
+    @email_unconfirmed = (logged_in? && current_user.confirmed?) ? false : true
   end
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -36,6 +36,12 @@ class DashboardsController < ApplicationController
     redirect_to root_path
   end
 
+  def resend_confirmation_email
+    current_user.send_confirmation_email
+    flash[:notice] = 'Confirmation email sent. Please check your inbox.'
+    redirect_to :back
+  end
+
   def confirm_email
     if params[:confirmation_token].present?
       user = User.where(confirmation_token: params[:confirmation_token]).first

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,6 +121,12 @@ class User < ActiveRecord::Base
     end
   end
 
+  def send_confirmation_email
+    generate_confirmation_token
+    self.save
+    ConfirmationMailer.confirmation(self).deliver
+  end
+
   def new_gift(attrs = {})
     GiftFactory.create!(self, gift_factory, attrs)
   end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -76,6 +76,11 @@
                 .alert= flash[:alert]
               - if flash[:notice]
                 .alert.alert-info= flash[:notice]
+          - if @email_unconfirmed
+            .alert.alert-info
+              You must confirm your email address. 
+              = link_to "Click here", resend_confirmation_path
+              to resend confirmation email.
     .container.block= yield
 
   %footer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Tfpullrequests::Application.routes.draw do
   end
   resource :pull_request_download, only: :create
 
+  get '/resend_confirmation', to: 'dashboards#resend_confirmation_email', as: 'resend_confirmation'
   get '/confirm/:confirmation_token', to: 'dashboards#confirm_email', as: 'confirm_email'
 
   get '/preferences',        to: 'dashboards#preferences',        as: 'preferences'


### PR DESCRIPTION
For #778.
Hope this approach is okay. But there is a failing test in `SPEC=spec/controllers/pull_request_downloads_controller_spec.rb`.

```
 1) PullRequestDownloadsController POST 'create' returns http success
     Failure/Error: post 'create'
       Double :user received unexpected message :confirmed? with (no args)
     # ./app/controllers/application_controller.rb:40:in `unconfirmed_email_alert'
     # ./spec/controllers/pull_request_downloads_controller_spec.rb:19:in `block (3 levels) in <top (required)>'
```

Not sure how to fix this. :cry:.

Can we just add `allow(user).to receive(:confirmed?)` in it?
