### PR TITLE
Change remove button text for twitter

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,7 +178,7 @@ en:
       information: You can always change your email preferences later.
       twitter: Twitter Account
       languages: Which languages do you know?
-      remove: Remove Account
+      remove: Unlink Twitter Account
       save: Save
       save_and_continue: Save and Continue
       coderwall: Link your coderwall account to display the badges you have already earned on your profile page.


### PR DESCRIPTION
Button text was misleading as could imply will remove whole account.
Updated to be clearer.
From this

![screen shot 2014-12-13 at 14 15 04](https://cloud.githubusercontent.com/assets/4692218/5424004/3b227590-82d4-11e4-8957-ebdc1406df99.png)

To this:

![screen shot 2014-12-13 at 14 15 18](https://cloud.githubusercontent.com/assets/4692218/5424007/41c9607a-82d4-11e4-80da-be0ec70274a7.png)
