### PR TITLE
Remove email confirmation alert when no email is required

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -73,4 +73,9 @@ module ApplicationHelper
   def unconfirmed_email?
     logged_in? && !current_user.confirmed?
   end
+
+  def helpful_emails?
+    logged_in? && current_user.email_frequency != 'none'
+  end
+
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -76,7 +76,7 @@
                 .alert= flash[:alert]
               - if flash[:notice]
                 .alert.alert-info= flash[:notice]
-          - if unconfirmed_email?
+          - if helpful_emails? && unconfirmed_email?
             .alert.alert-info
               You must confirm your email address.
               = link_to "Click here", resend_confirmation_path


### PR DESCRIPTION
The user doesn't receive a message for email confirmation if he/she doesn't want to receive helpful emails.
