### PR TITLE
Email link fix on 404 page

### DIFF
--- a/app/views/errors/not_found.html.haml
+++ b/app/views/errors/not_found.html.haml
@@ -6,4 +6,4 @@
     Still lost?
     %a{ :href => 'http://24pullrequests.com/'} Go back to the home page
     or email us at
-    %a{ :href => "mailto: info@24pullrequests.com" } info@24pullrequests.com
+    %a{ :href => "mailto:info@24pullrequests.com" } info@24pullrequests.com


### PR DESCRIPTION
Fixes the mailto link not workign due to the space on the 404 page.
