### PR TITLE
Redirect the user back to where they came from after linking their twitter account.

### DIFF
--- a/app/controllers/twitter_controller.rb
+++ b/app/controllers/twitter_controller.rb
@@ -3,7 +3,7 @@ class TwitterController < ApplicationController
     auth_hash = request.env['omniauth.auth']
     current_user.authorize_twitter!(auth_hash.info.nickname, auth_hash.credentials.token, auth_hash.credentials.secret)
     flash[:notice] = I18n.t 'twitter.account_linked'
-    redirect_to dashboard_path
+    redirect_to :back
   end
 
   def remove


### PR DESCRIPTION
When a user links their twitter account they are redirected to the dashboard, it makes more sense for the user to be redirected to the page in which they performed the action (only the profile page as far as I can tell).
