### PR TITLE
Add description for Logout link

### DIFF
--- a/app/views/application/_user_nav.html.haml
+++ b/app/views/application/_user_nav.html.haml
@@ -4,6 +4,7 @@
       %li.logout
         = link_to logout_path, :title => t("navigation.logout") do
           %span.octicon.octicon-sign-out
+          = t("navigation.logout")
 
       %li
         = link_to dashboard_path do


### PR DESCRIPTION
This makes it more accessible, especially for mobile, where there is only a small icon at the side.
