### PR TITLE
Add meta information to the pull requests endpoint.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'coffee-rails'
 gem 'uglifier'
 gem 'octicons-rails'
 gem 'rack-canonical-host'
+gem 'draper'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,11 @@ GEM
     diff-lcs (1.2.5)
     docile (1.1.5)
     dotenv (1.0.2)
+    draper (1.4.0)
+      actionpack (>= 3.0)
+      activemodel (>= 3.0)
+      activesupport (>= 3.0)
+      request_store (~> 1.0)
     ejs (1.1.1)
     equalizer (0.0.9)
     erubis (2.7.0)
@@ -281,6 +286,7 @@ GEM
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
+    request_store (1.1.0)
     rest-client (1.7.2)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
@@ -427,6 +433,7 @@ DEPENDENCIES
   coveralls
   dalli
   database_cleaner
+  draper
   ejs
   factory_girl_rails
   faker

--- a/app/controllers/pull_requests_controller.rb
+++ b/app/controllers/pull_requests_controller.rb
@@ -2,7 +2,17 @@ class PullRequestsController < ApplicationController
   respond_to :html, :json
 
   def index
-    @pull_requests = PullRequest.year(current_year).order('created_at desc').includes(:user).page params[:page]
+    @pull_requests = pull_requests.page(params[:page])
     respond_with @pull_requests
+  end
+
+  def meta
+    @pull_requests_decorator = PullRequestsDecorator.new(pull_requests)
+    respond_with @pull_requests_decorator
+  end
+
+  protected
+  def pull_requests
+    PullRequest.year(current_year).order('created_at desc').includes(:user)
   end
 end

--- a/app/decorators/app_decorator.rb
+++ b/app/decorators/app_decorator.rb
@@ -1,0 +1,19 @@
+class AppDecorator < Draper::Decorator
+
+  class << self
+    attr_accessor :attributes
+
+    def attributes(*args)
+      self.class_eval do
+        define_method(:attributes) do
+          args.inject({}) do |memo, item|
+            memo[item] = self.send(item)
+            memo
+          end
+        end
+      end
+    end
+
+  end
+
+end

--- a/app/decorators/pull_requests_decorator.rb
+++ b/app/decorators/pull_requests_decorator.rb
@@ -1,0 +1,14 @@
+class PullRequestsDecorator < AppDecorator
+  delegate_all
+
+  attributes :count, :total_pages
+
+  def total_pages
+    object.page(1).total_pages
+  end
+
+  def paginated
+    object.page(1)
+  end
+
+end

--- a/app/views/pull_requests/meta.html.haml
+++ b/app/views/pull_requests/meta.html.haml
@@ -1,0 +1,7 @@
+%h2
+  - if @language
+    =t("pull_requests.language.count", count: pull_request_count, language: @language)
+  - else
+    =t("pull_requests.count", count: pull_request_count)
+= render @pull_requests_decorator.paginated
+= paginate @pull_requests_decorator.paginated

--- a/app/views/static/api.html.haml
+++ b/app/views/static/api.html.haml
@@ -117,6 +117,17 @@
       }
     ]
 
+%p=t("api.pull_requests.meta_details")
+
+%pre
+  :plain
+    $ curl http://24pullrequests.com/pull_requests/meta.json
+
+    {
+      "count": 500,
+      "total_pages": 20
+    }
+
 %h2=t("api.users.title")
 
 %p=t("api.users.details")

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -240,6 +240,7 @@ de:
     pull_requests:
       title:
       details:
+      meta_details:
     users:
       title:
       details:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -241,6 +241,7 @@ el:
     pull_requests:
       title:
       details:
+      meta_details:
     users:
       title:
       details:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -274,6 +274,7 @@ en:
     pull_requests:
       title: Pull Requests
       details: Load all pull requests by users of the site during December, ordered by newest first, also includes the user who made the pull request.
+      meta_details: Load information about all the pull requests this year.
     users:
       title: Users
       details: Load all users who have signed up to the site, ordered by how many pull requests they have sent so far in December, also includes their organisation(s) and pull requests.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -240,6 +240,7 @@ es:
     pull_requests:
       title:
       details:
+      meta_details:
     users:
       title:
       details:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -238,6 +238,7 @@ fi:
     pull_requests:
       title:
       details:
+      meta_details:
     users:
       title:
       details:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -243,6 +243,7 @@ fr:
     pull_requests:
       title:
       details:
+      meta_details:
     users:
       title:
       details:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -244,6 +244,7 @@ it:
     pull_requests:
       title: Pull Request
       details: Carica tutte le pull request degli utenti del sito inviate in dicembre, elencando per prime quelle più nuove, includendo anche l'utente che ha inviato la pull request
+      meta_details: Caricare le informazioni su tutte le richieste di trazione di quest'anno.
     users:
       title: Utenti
       details: Carica tutti gli utenti che si sono iscritti al sito, ordinati per la quantità di pull request che hanno inviato in dicembre, includendo le loro organizzazioni e le pull request

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -270,6 +270,7 @@ ja:
     pull_requests:
       title: Pull Requests
       details: このサイトのユーザによる12月中の全ての pull request を新しいもの順に返します。pull request を作成したユーザ情報も含まれます。
+      meta_details: 今年すべてのプル要求についての情報をロードします。
     users:
       title: Users
       details: このサイトにサインアップしている全てのユーザを、12月中の pull request が多い順に返します。組織情報、pull request 情報も含まれます。

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -245,6 +245,7 @@ nb:
     pull_requests:
       title: Pull Requests
       details: Hent alle pull requests fra brukere of siden i desember, sortert med den nyeste først. Inkluderer også brukeren som gjorde pull requesten.
+      meta_details: Laste informasjon om alle pull forespørsler i år.
     users:
       title: Brukere
       details: Hent alle brukere som har signet opp på siden, sortert etter hvor mange pull requests de har sendt så langt i desember. Inkluderer også deres organisasjon(er) og pull requests.

--- a/config/locales/pt_br.yml
+++ b/config/locales/pt_br.yml
@@ -270,6 +270,7 @@ pt_br:
     pull_requests:
       title: "Pull Requests"
       details: "Retorna todos os pull requests dos usuários do site durante dezembro, ordenados por data, mais novos primeiro. também inclui o usuário que fez o pull request."
+      meta_details: "Coloque informações sobre todos os pedidos de puxar este ano."
     users:
       title: "Usuários"
       details: "Retorna todos os usuários que se increveram no site, ordenado pela quantidade de pull requests enviados durante o mês de dezembro. Também inclui suas organizações de pull requests."

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -248,6 +248,7 @@ ru:
     pull_requests:
       title:
       details:
+      meta_details:
     users:
       title:
       details:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -248,6 +248,7 @@ ta:
     pull_requests:
       title: Pull Requests
       details: Load all pull requests by users of the site during December, ordered by newest first, also includes the user who made the pull request.
+      meta_details: Load information about all the pull requests this year.
     users:
       title: Users
       details: Load all users who have signed up to the site, ordered by how many pull requests they have sent so far in December, also includes their organisation(s) and pull requests.

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -239,6 +239,7 @@ th:
     pull_requests:
       title:
       details:
+      meta_details:
     users:
       title:
       details:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -243,6 +243,7 @@ tr:
     pull_requests:
       title: Pull Requests
       details: Kullanıcının kendi yaptığı pull request'ler dahil olmak üzere tüm pull requestler Aralık ayındankiler olmak üzere yeniden eskiye doğru sıralanır.
+      meta_details: Bu yıl tüm çekme istekleri hakkında bilgi yükleyin.
     users:
       title: Kullanıclar
       details: Siteye kayıtlı tüm kullanıcılar Aralık ayı boyunca kendi ve organizasyonları üzerinden yaptıkları pull requestler'i görürler.

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -240,6 +240,7 @@ uk:
     pull_requests:
       title:
       details:
+      meta_details:
     users:
       title:
       details:

--- a/config/locales/zh_Hans.yml
+++ b/config/locales/zh_Hans.yml
@@ -244,6 +244,7 @@ zh_Hans:
     pull_requests:
       title: Pull Requests
       details: 在12月份当之所有的合并请求(pull request)，按照时间排序（包含用户）
+      meta_details: 加载所有拉请求的信息，今年。
     users:
       title: Users
       details: 所有注册用户，按照他们今年合并请求(pull request)数量排序， 同时包含他们的组织信息和合并请求(pull request)信息。

--- a/config/locales/zh_Hant.yml
+++ b/config/locales/zh_Hant.yml
@@ -259,6 +259,7 @@ zh_Hant:
     pull_requests:
       title: "Pull Requests"
       details: "在 12 月份當之所有的 Pull Requests，按照時間排序（包含使用者資訊）"
+      meta_details: 加载所有拉请求的信息，今年。
     users:
       title: "使用者"
       details: "所有註冊使用者，按照他們今年的 Pull Requests 數量排序，同時也包含他們的組織細節和 Pull Request 資料。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,12 @@ Tfpullrequests::Application.routes.draw do
     end
   end
 
-  resources :pull_requests, only: [:index]
+  resources :pull_requests, only: [:index] do
+    collection do
+      get :meta
+    end
+  end
+
   resource :dashboard, only: [:show, :destroy] do
     member do
       get :delete

--- a/spec/decorators/pull_requests_decorator_spec.rb
+++ b/spec/decorators/pull_requests_decorator_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe PullRequestsDecorator do
+
+  before do
+    100.times do
+      FactoryGirl.create :pull_request, body: 'happy 24 pull requests!'
+    end
+  end
+
+  subject { PullRequestsDecorator.new(PullRequest.all) }
+
+  describe '#attributes' do
+
+    it 'gives me the correct count' do
+      expect(subject.attributes[:count]).to eq(100)
+    end
+
+    it 'gives me the correct page count' do
+      expect(subject.attributes[:total_pages]).to eq(4)
+    end
+
+    it 'gives me only the keys I want' do
+      expect(subject.attributes.keys).to eq([:count, :total_pages])
+    end
+
+  end
+
+end


### PR DESCRIPTION
On the dashboard we want the last display to be the "total pull requests" so instead of making hundreds of api requests, I figured this would be a little nicer.

```
-> % curl -i http://127.0.0.1:3000/pull_requests/meta.json
HTTP/1.1 200 OK
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Content-Type: application/json; charset=utf-8
ETag: "62ea61d4dfb933326182e82e25183552"
Cache-Control: max-age=0, private, must-revalidate
X-Request-Id: 91d55997-5b54-4b10-9d4e-c8a9f5267866
X-Runtime: 0.084581
Vary: Accept-Encoding
Connection: close
Server: thin

{"count":563,"total_pages":23}
```

The html view just mirrors the pull_requests html endpoint.
