### PR TITLE
Project counts should only count active projects

### DIFF
--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -1,5 +1,5 @@
 %h2
-  = Project.count
+  = Project.active.count
   = t("suggested_projects")
   = link_to t("suggest_project"), new_project_path, :class => 'btn btn-default pull-right'
 

--- a/app/views/static/homepage.html.haml
+++ b/app/views/static/homepage.html.haml
@@ -92,7 +92,7 @@
         .title-block
           %span.mega-octicon.octicon-repo
           %h3.block-title
-            = Project.count
+            = Project.active.count
             = t("suggested_projects")
           %p=t("dashboard.help_out")
           = link_to t("suggest_project"), new_project_path, :class => 'btn btn-default btn-sm'


### PR DESCRIPTION
Now that I've made more projects in active, this makes the count match the actual amount of projects we'll suggest.
