### PR TITLE
Ignore all the automatic coderwall orgs

### DIFF
--- a/app/models/pull_request_downloader.rb
+++ b/app/models/pull_request_downloader.rb
@@ -36,28 +36,11 @@ class PullRequestDownloader
   def download_user_organisations
     github_client.user_organizations.reject do |o|
       Rails.logger.info "Updating organisation: #{o.login}"
-      ignored_organisations.include?(o.login)
+      o.login.match(/^coderwall-/)
     end
   rescue => e
     Rails.logger.error "Organisation error: likely a GitHub API error occurred:\n"\
                        "#{e.inspect}"
     []
-  end
-
-  def ignored_organisations
-    [
-      'coderwall-altruist',
-      'coderwall-charity',
-      'coderwall-kona',
-      'coderwall-cub',
-      'coderwall-earlyadopter',
-      'coderwall-forked',
-      'coderwall-komododragon',
-      'coderwall-mongoose',
-      'coderwall-mongoose3',
-      'coderwall-octopussy',
-      'coderwall-raven',
-      'coderwall-polygamous'
-    ]
   end
 end


### PR DESCRIPTION
They just make the org list look messy
