### PR TITLE
Fix intermittently failing test

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -100,7 +100,7 @@ describe ApplicationHelper, type: :helper do
     end
 
     it 'projects_in(year)' do
-      3.times { create(:pull_request, repo_name: '24pullrequests', created_at: DateTime.now - 1.year) }
+      create(:pull_request, repo_name: '24pullrequests', created_at: DateTime.now - 1.year)
 
       expect(helper.projects_in(last_year)).to eq(2)
     end


### PR DESCRIPTION
The 3 factory PRs created in the `before.do` loop would very occasionally have duplicate repo_name's due to `repo_name { Faker::Lorem.words.first }` in `factories.rb` not being guaranteed to be unique each time.

The easy solution was just to pass a repo_name in, as the other tests in this block do not depend on repo_name being different. I also changed the test so that it only creates one PR, as 3 isn't necessary to test the condition.
