### PR TITLE
Update title and body of pull request on sync. Fixes #849

### DIFF
--- a/app/services/downloader.rb
+++ b/app/services/downloader.rb
@@ -22,7 +22,14 @@ class Downloader
 
   def get_pull_requests
     user_downloader.pull_requests.each do |pr|
-      user.pull_requests.create_from_github(pr) unless pull_request_exists?(pr)
+      if pull_request = pull_request_exists?(pr)
+        pull_request.update(
+          title: pr['payload']['pull_request']['title'],
+          body: pr['payload']['pull_request']['body']
+        )
+      else
+        user.pull_requests.create_from_github(pr)
+      end
     end
   end
 
@@ -35,6 +42,6 @@ class Downloader
   end
 
   def pull_request_exists?(pull_request)
-    user.pull_requests.find_by_issue_url(pull_request['payload']['pull_request']['_links']['html']['href']).present?
+    user.pull_requests.find_by_issue_url(pull_request['payload']['pull_request']['_links']['html']['href'])
   end
 end

--- a/spec/services/downloader_spec.rb
+++ b/spec/services/downloader_spec.rb
@@ -43,6 +43,21 @@ describe Downloader do
 
       expect(user.pull_requests.length).to eq(1)
     end
+
+    it "when the pull request already exists it updates it" do
+      old_title = pull_request['payload']['pull_request']['title']
+      old_body = pull_request['payload']['pull_request']['body']
+      updated_pull_request = pull_request.clone
+      updated_pull_request['payload']['pull_request']['title'] += 'updated'
+      updated_pull_request['payload']['pull_request']['body'] += 'updated'
+
+      double(:user_downlaoder, pull_requests: [pull_request, updated_pull_request])
+      downloader.get_pull_requests
+
+      expect(user.pull_requests.length).to eq(1)
+      expect(user.pull_requests.first.title).to eq(old_title + 'updated')
+      expect(user.pull_requests.first.body).to eq(old_body + 'updated')
+    end
   end
 
   def double_organisation


### PR DESCRIPTION
Add update on sync. Checks for existing pull request, then updates title and body if it exists.
