### PR TITLE
Enable migration error on development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,6 +19,9 @@ Tfpullrequests::Application.configure do
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
 
+  # Raise an error on page load if there are pending migrations.
+  config.active_record.migration_error = :page_load
+
   # Do not compress assets
   config.assets.compress = false
 


### PR DESCRIPTION
When we forget `rake db:migrate`,
the migration error is helpful for local development.
