### PR TITLE
github urls don't have www

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -26,7 +26,7 @@ class Project < ActiveRecord::Base
   belongs_to :submitted_by, class_name: 'User', foreign_key: :user_id
 
   validates :description, :github_url, :name, :main_language, presence: true
-  validates :github_url, format: { with: /\Ahttps?:\/\/(www\.)?github.com\/[\w-]+\/[\w\.-]+(\/)?\Z/i, message: 'Enter a valid GitHub URL.' }
+  validates :github_url, format: { with: /\Ahttps?:\/\/github.com\/[\w-]+\/[\w\.-]+(\/)?\Z/i, message: 'Enter a valid GitHub URL.' }
   validates :github_url, uniqueness: { case_sensitive: false, message: 'Project has already been suggested.' }
   validates_length_of :description, within: 20..200
   validates_inclusion_of :main_language, in: LANGUAGES, message: 'must be a programming language'


### PR DESCRIPTION
I receive the daily remainder for 24pullrequests and it had repeated elements, because one url had `www.` and the other didn't. Github doesn't use `www.` and redirects `www.` to non `www.`

![screen shot 2014-12-20 at 10 23 43 pm](https://cloud.githubusercontent.com/assets/1312687/5517137/e37ef020-8896-11e4-9ad8-f3e10f2d1436.png)
