### PR TITLE
Move toward assigning all PRs automatically

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -139,6 +139,19 @@ class User < ActiveRecord::Base
     Gift.find(id, date)
   end
 
+  def ungifted_dates
+    Gift.giftable_dates - gifts.pluck(:date)
+  end
+
+  def gift_unspent_pull_requests
+    if ungifted_dates.any?
+      pull_requests = unspent_pull_requests.slice(0, ungifted_dates.count)
+      pull_requests.each do |pull_request|
+        new_gift(pull_request: pull_request).save
+      end
+    end
+  end
+
   def send_regular_emails?
     %w(daily weekly).include?(email_frequency)
   end

--- a/app/services/gift_factory.rb
+++ b/app/services/gift_factory.rb
@@ -13,18 +13,14 @@ class GiftFactory
 
   def create_from_attrs(attrs = {})
     gift = @factory.call(attrs)
-    gift.date ||= closest_free_gift_date
+    gift.date = earliest_free_gift_date
     gift.user = @user
     gift
   end
 
   private
 
-  def closest_free_gift_date
-    previous_gift.present? ? previous_gift.date + 1.day : PullRequest::EARLIEST_PULL_DATE
-  end
-
-  def previous_gift
-    @previous_gift ||= @user.gifts.last
+  def earliest_free_gift_date
+    @user.ungifted_dates.first || PullRequest::EARLIEST_PULL_DATE
   end
 end

--- a/lib/tasks/pull_requests.rake
+++ b/lib/tasks/pull_requests.rake
@@ -42,3 +42,10 @@ task update_pull_requests: :environment do
     pr.check_state rescue nil
   end
 end
+
+desc "Gift unspent pull requests"
+task :gift_unspent_requests => :environment do
+  User.all.each do |user|
+    user.gift_unspent_pull_requests!
+  end
+end

--- a/spec/services/gift_factory_spec.rb
+++ b/spec/services/gift_factory_spec.rb
@@ -1,11 +1,12 @@
+require 'rails_helper'
+
 describe GiftFactory do
   let(:user) { FactoryGirl.create(:user) }
   let(:pull_request) { FactoryGirl.create(:pull_request) }
   let(:gift_factory) { Gift.public_method(:new) }
 
-  describe '#create!' do
-
-    it 'generates a new gift for the user' do
+  describe "#create!" do
+    it "generates a new gift for the user" do
       gift = GiftFactory.create!(user, gift_factory, pull_request_id: pull_request.id)
       expect(gift.pull_request).to eq(pull_request)
     end
@@ -16,7 +17,26 @@ describe GiftFactory do
       factory = GiftFactory.new(user, gift_factory)
       gift = factory.create_from_attrs({})
 
-      expect(gift.date).to eq(Gift.default_date)
+      expect(gift.date).to eq(PullRequest::EARLIEST_PULL_DATE)
+    end
+  end
+
+  context "when the user has gifted some PRs" do
+    describe "#create_from_attrs" do
+      before do
+        user.gifts.create!({
+          user: user,
+          pull_request: pull_request,
+          date: Date.new(CURRENT_YEAR, 12, 5)
+        })
+      end
+
+      it "creates a new present" do
+        factory = GiftFactory.new(user, gift_factory)
+        gift = factory.create_from_attrs({})
+
+        expect(gift.date).to eq(PullRequest::EARLIEST_PULL_DATE)
+      end
     end
   end
 end


### PR DESCRIPTION
This branch contains changes to the GiftFactory that will ascertain the earliest available date, rather than most recently available date.  It also includes a rake task for automatically assigning all users currently unspent pull requests.

If this makes sense/is acceptable, I will go ahead and make it happen automatically on synchronization etc... /cc @andrew 
