### PR TITLE
rederict to where user was when updating preferences

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -19,11 +19,16 @@ class DashboardsController < ApplicationController
                             gift_form:     gift_form }
   end
 
+  def preferences
+    session[:preferences_referrer] = request.referrer unless current_user.email_frequency.nil?
+  end
+
   def update_preferences
     current_user.skills.delete_all
     if current_user.update_attributes(user_params)
       flash[:success] = 'Your preferences was successfully saved'
-      redirect_to :back
+      redirect_to session[:preferences_referrer] || dashboard_path
+      session.delete(:preferences_referrer)
     else
       render :preferences
     end


### PR DESCRIPTION
Right now when you edit your preferences you are redirected :back which is the preferences again, this fixes that issue. When you are a new user it redirects you to dashboard, previously it redirected you to preferences as well.
