### PR TITLE
not requiring rspec when rails loads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,14 +36,14 @@ group :development do
 end
 
 group :development, :test, :cucumber do
-  gem 'rspec-rails'
+  gem 'rspec-rails', require: false
   gem 'coveralls', require: false
   gem 'codeclimate-test-reporter', require: nil
   gem 'pullreview-coverage', require: false
 
-  gem 'rspec-its'
-  gem 'rspec-collection_matchers'
-  gem 'rspec-activemodel-mocks'
+  gem 'rspec-its', require: false
+  gem 'rspec-collection_matchers', require: false
+  gem 'rspec-activemodel-mocks', require: false
   gem 'factory_girl_rails'
   gem 'faker'
   gem 'brakeman'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,6 +21,9 @@ require 'rails/application'
 
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
+require 'rspec/active_model/mocks'
+require 'rspec/its'
+require 'rspec/collection_matchers'
 # require 'rspec/autorun'
 require 'shoulda-matchers'
 require 'webmock'


### PR DESCRIPTION
This also removes the `irb` warning `irb: warn: can't alias context from irb_context.`. :+1: 
