### PR TITLE
Full Auto Gift.  No more dailies.

### DIFF
--- a/app/services/downloader.rb
+++ b/app/services/downloader.rb
@@ -29,7 +29,6 @@ class Downloader
         )
       else
         pull_request = user.pull_requests.create_from_github(pr)
-        auto_gift_today(pull_request) unless gifted_any_today?
       end
     end
   end


### PR DESCRIPTION
The new approach of auto-gifting didn't include remove the logic to always gift the first PR of the day to that day.  The mixture is terrible, so this commit removes the 'on the day' gifting.
