### PR TITLE
Change for proper day plurality in email

### DIFF
--- a/app/views/reminder_mailer/_mail_content.html.haml
+++ b/app/views/reminder_mailer/_mail_content.html.haml
@@ -3,7 +3,10 @@
 %p
   Only
   = 25 - Date.today.day
-  days left until Christmas!
+  - if (25 - Date.today.day) > 1
+    days left until Christmas!
+  - else
+    day left until Christmas!
 
 %p We've got some suggested projects for you to send pull requests to this #{this_time}.
 

--- a/app/views/reminder_mailer/_mail_content.text.erb
+++ b/app/views/reminder_mailer/_mail_content.text.erb
@@ -1,6 +1,6 @@
 Hi <%= @user.nickname %>,
 
-Only <%= 25 - Date.today.day %> days left until Christmas!
+Only <%= 25 - Date.today.day %> <% if (25 - Date.today.day) > 1 %>days<%else%>day<%end%> left until Christmas!
 
 We've got some suggested projects for you to send pull requests to <%= this_time %>
 


### PR DESCRIPTION
Woke up, checked my email, thought "that's funny, it says _1 days_, thought "oh let me go fix it".
