### PR TITLE
Use new linear-gradient syntax on static.css

### DIFF
--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -25,7 +25,7 @@
       right: 0;
       width: 1em;
       background: -webkit-linear-gradient(left, rgba(#fff,0), #fff);
-      background: linear-gradient(left, rgba(#fff,0), #fff);
+      background: linear-gradient(to right, rgba(#fff,0), #fff);
     }
   }
 }


### PR DESCRIPTION
The `linear-gradient` syntax has changed, now it's `to right` instead of `left`. 
Fixes #938