### PR TITLE
Upgraded shoulda-matchers gem to 3.0.1 and undid previous workaround commit.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,7 +198,7 @@ GEM
     multipart-post (2.0.0)
     naught (1.1.0)
     netrc (0.10.3)
-    newrelic_rpm (3.13.2.302)
+    newrelic_rpm (3.14.0.305)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     oauth (0.4.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,7 +221,7 @@ GEM
     omniauth-oauth (1.1.0)
       oauth
       omniauth (~> 1.0)
-    omniauth-oauth2 (1.3.1)
+    omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     omniauth-twitter (1.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,7 +339,7 @@ GEM
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
     sexp_processor (4.6.0)
-    shoulda-matchers (3.0.0)
+    shoulda-matchers (3.0.1)
       activesupport (>= 4.0.0)
     simple_form (3.2.0)
       actionpack (~> 4.0)

--- a/spec/models/gift_spec.rb
+++ b/spec/models/gift_spec.rb
@@ -9,10 +9,7 @@ describe Gift, type: :model do
   it { is_expected.to validate_presence_of(:user) }
   it { is_expected.to validate_presence_of(:pull_request) }
   it { is_expected.to validate_presence_of(:date) }
-
-  it 'check that gift.date is among valid Gift.giftable_dates' do
-    expect(Gift.giftable_dates.include?(gift.date)).to be true
-  end
+  it { is_expected.to validate_inclusion_of(:date).in_array(Gift.giftable_dates) }
 
   describe '#find' do
     subject { described_class.find(user, Time.zone.now.to_date) }


### PR DESCRIPTION
Upgraded shoulda-matchers gem to 3.0.1 and undid the spec/model/gift_spec.rb workaround in this commit: https://github.com/jasnow/24pullrequests/commit/0fd4bb8949c159588c36decdf449af6048efb585

