### PR TITLE
Upgraded autoprefixer-rails, coveralls, and simplecov gems. Fixed #999, #997, #988.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     ast (2.1.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
-    autoprefixer-rails (6.1.1)
+    autoprefixer-rails (6.1.2)
       execjs
       json
     binding_of_caller (0.7.2)
@@ -85,10 +85,10 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     colorize (0.7.7)
-    coveralls (0.8.9)
+    coveralls (0.8.10)
       json (~> 1.8)
       rest-client (>= 1.6.8, < 2)
-      simplecov (~> 0.10.0)
+      simplecov (~> 0.11.0)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
       tins (~> 1.6.0)
@@ -350,7 +350,7 @@ GEM
       actionpack (~> 4.0)
       activemodel (~> 4.0)
     simple_oauth (0.3.1)
-    simplecov (0.10.0)
+    simplecov (0.11.0)
       docile (~> 1.1.0)
       json (~> 1.8)
       simplecov-html (~> 0.10.0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,7 @@
 require 'simplecov'
 require 'coveralls'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]


### PR DESCRIPTION
Upgraded autoprefixer-rails, coveralls, and simplecov gems. Fixed #999, #997, #988.

Fixed dep warning in **spec/rails_helper.rb** file based on section, **Using multiple formatters**, in this file: https://github.com/colszowka/simplecov 
