### PR TITLE
Reject empty map markers, it makes a mess of the javascript

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -18,7 +18,7 @@ class StaticController < ApplicationController
 
         marker.lat user.lat
         marker.lng user.lng
-      end
+      end.reject { |m| m.empty? }
     end
   end
 


### PR DESCRIPTION
My precious contributor map doesn't render on the live site because for whatever the reason, some of the map markers are coming back as empty objects.

This rejects those inside the cache block.