### PR TITLE
Fixed #992 - "warning:  duplicated key at line 3 ignored: :alt"

### DIFF
--- a/app/views/organisations/_organisation.html.haml
+++ b/app/views/organisations/_organisation.html.haml
@@ -1,6 +1,6 @@
 %li.avatar-cell
   = link_to organisation_path(organisation.login), class: "avatar-link" do
-    = image_tag(organisation.avatar_url(160), alt: organisation.login, class: "avatar-img", alt: " ")
+    = image_tag(organisation.avatar_url(160), alt: organisation.login, class: "avatar-img")
     .username @#{organisation.login}
     %span.pr-badge
       %span.octicon.octicon-git-pull-request


### PR DESCRIPTION
 * BEFORE/CURRENT (in "rails s" log):
```
   (0.7ms)  SELECT COUNT(*) FROM "users"
  Rendered users/_user.html.haml (15.7ms)
   (0.8ms)  SELECT COUNT(*) FROM "organisations"
/home/jasnow/Projects/24pullrequests/app/views/organisations/_organisation.html.haml:3: warning: duplicated key at line 3 ignored: :alt
  Rendered organisations/_organisation.html.haml (16.6ms)
   (2.1ms)  SELECT COUNT(*) FROM "pull_requests" WHERE (EXTRACT(year FROM "created_at") = 2015)
```
 * SO I REMOVED THIS: **', alt: " "'** on line 3 of app/views/organisations/_organisation.html.haml file

 * AFTER/FIXED (in "rails s" log):
```
   (0.7ms)  SELECT COUNT(*) FROM "users"
  Rendered users/_user.html.haml (14.8ms)
   (0.7ms)  SELECT COUNT(*) FROM "organisations"
  Rendered organisations/_organisation.html.haml (18.8ms)
   (2.2ms)  SELECT COUNT(*) FROM "pull_requests" WHERE (EXTRACT(year FROM "created_at") = 2015)
```
