### PR TITLE
Fixed issue with timeago not being reapplied after refreshing PRs

### DIFF
--- a/app/assets/javascripts/dashboard.js.coffee
+++ b/app/assets/javascripts/dashboard.js.coffee
@@ -13,3 +13,4 @@ $ ->
         $('#pull-requests-count').html $('.pull_request').length
         $("#spinner, #search_button").toggle()
         emojify()
+        $('abbr.timeago').timeago()


### PR DESCRIPTION
Hey :wave:  

Playing around with the dashboard I realised that clicking the Synchronize Pull Requests button changes the created at display for the Pull Requests from a human friendly time ago in words:

![pr_timeago](https://cloud.githubusercontent.com/assets/1451215/11601335/5367148a-9aca-11e5-89cf-863cdb16a565.png)

to an ISO 8601 format

![pr_iso8601](https://cloud.githubusercontent.com/assets/1451215/11601390/c24d26a0-9aca-11e5-8e05-d017d24f35c8.png)

I believe this to be incorrect behaviour, if that's not the case please do ignore this PR.

This PR fixes this behaviour and retains the formatting after the refresh.

I've had a look for some JS specs and couldn't find any so I've not included any as part of this PR.

Hope this is all ok.

Thanks,
.FxN

ps. :heart: this project! Thanks so much for running it