### PR TITLE
Upgraded bugsnag gem to 2.8.13. Fixed #1045.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       slim (>= 1.3.6, < 4.0)
       terminal-table (~> 1.4)
     buftok (0.2.0)
-    bugsnag (2.8.12)
+    bugsnag (2.8.13)
       json (~> 1.7, >= 1.7.7)
     builder (3.2.2)
     capybara (2.5.0)


### PR DESCRIPTION
Upgraded bugsnag gem to 2.8.13. Fixed #1045.