### PR TITLE
Real-time endpoint for Dasher #1047

### DIFF
--- a/app/controllers/admin/dasher_controller.rb
+++ b/app/controllers/admin/dasher_controller.rb
@@ -1,0 +1,20 @@
+class Admin::DasherController < ApplicationController
+	skip_before_action :verify_authenticity_token
+
+	before_action :check_api_key
+
+	def new_pull_request
+		user = User.find_by_nickname(params['actor']['login'])
+		if user 
+			user.pull_requests.create_from_github(params)
+		end
+		head :ok
+	end
+
+	private 
+	def check_api_key
+		if ENV['API_KEY'] != params['api_key']
+			render :json => { error: "Error incorrect api key" }, :status => :bad_request
+		end
+	end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Tfpullrequests::Application.routes.draw do
   get '/:id' => redirect('/users/%{id}') # User public vanity url, must be lowest priority
 
   namespace :admin do
+    post '/dasher', to: 'dasher#new_pull_request'
     resources :projects, only: [:index, :edit, :update, :destroy]
   end
 end


### PR DESCRIPTION
Integrate Dasher for real-time tracking of user pull requests-includes verification of api key. [Dasher]( https://github.com/24pullrequests/dasher) receives Github events from the Firehose Api and posts them to this endpoint.

This means we are able to track as soon as they are opened as opposed to repeated checking.

@Codebar
:snowman: 