### PR TITLE
Changed call to action from 'What more options?' to 'Want more options?'

### DIFF
--- a/app/views/static/api.html.haml
+++ b/app/views/static/api.html.haml
@@ -70,7 +70,7 @@
       )
 
 .alert.alert-info
-  %strong What more options?
+  %strong Want more options?
   Open an issue on
   = link_to 'GitHub', 'https://github.com/24pullrequests/24pullrequests'
   if you would like more features in the API, or even send us a pull request!


### PR DESCRIPTION
Hey :wave: 

Just a quick one fixing the call to action text on the static API page. The call to action reads: 'What more options?' I believe this was intended to read 'Want more options?'

Thanks,
.FxN