### PR TITLE
Languages in alphabetical listing in columns on /preferences

### DIFF
--- a/app/assets/stylesheets/language.scss
+++ b/app/assets/stylesheets/language.scss
@@ -90,10 +90,8 @@
 
 .language-checkbox {
   padding: 4px 8px;
-  border: 1px solid #f5f5f5;
   cursor: pointer;
   white-space: nowrap;
-  width: 100%;
 
   input[type=checkbox] {
     margin-right: 4px;
@@ -102,15 +100,4 @@
   &:hover {
     background-color: #f5f5f5;
   }
-}
-
-@media (max-width: 400px) {
-  .col-languages {
-    width: 100%;
-  }
-}
-
-.xs-space {
-  display: block;
-  height: 40px;
 }

--- a/app/assets/stylesheets/language.scss
+++ b/app/assets/stylesheets/language.scss
@@ -93,12 +93,20 @@
   border: 1px solid #f5f5f5;
   cursor: pointer;
   white-space: nowrap;
+  width: 100%;
+
   input[type=checkbox] {
     margin-right: 4px;
   }
 
   &:hover {
     background-color: #f5f5f5;
+  }
+}
+
+@media (max-width: 400px) {
+  .col-languages {
+    width: 100%;
   }
 }
 

--- a/app/assets/stylesheets/language.scss
+++ b/app/assets/stylesheets/language.scss
@@ -92,7 +92,7 @@
   padding: 4px 8px;
   border: 1px solid #f5f5f5;
   cursor: pointer;
-
+  white-space: nowrap;
   input[type=checkbox] {
     margin-right: 4px;
   }
@@ -100,4 +100,9 @@
   &:hover {
     background-color: #f5f5f5;
   }
+}
+
+.xs-space {
+  display: block;
+  height: 40px;
 }

--- a/app/views/dashboards/preferences.html.haml
+++ b/app/views/dashboards/preferences.html.haml
@@ -23,13 +23,18 @@
         = form.input :email, :label => t("preferences.form.email")
     .col-md-12
       %h2.text-center=t("preferences.languages")
-      .row
-        = form.simple_fields_for :skills, Project::LANGUAGES.map{|l| Skill.new(:language => l)} do |skill_form|
-          - language = skill_form.object.language
+      .row.col-languages
+        - Project::LANGUAGES.in_groups(6, '') do |col_form| p col_form
           .col-xs-6.col-sm-4.col-md-2
-            %label.language-checkbox
-              = skill_form.check_box :language, {:id => language, :checked => current_user.skills.map(&:language).include?(language)}, language
-              = language
+            = form.simple_fields_for :skills, col_form.map{|l| Skill.new(:language => l)} do |skill_form|
+              - language = skill_form.object.language
+              .col-md-12
+                - if !language.empty?
+                  %label.language-checkbox
+                    = skill_form.check_box :language, {:id => language, :checked => current_user.skills.map(&:language).include?(language)}, language
+                    = language
+                - else
+                  .xs-space
     .form-group
       .col-sm-12.text-center
         - if current_user.needs_setup?

--- a/app/views/dashboards/preferences.html.haml
+++ b/app/views/dashboards/preferences.html.haml
@@ -23,18 +23,19 @@
         = form.input :email, :label => t("preferences.form.email")
     .col-md-12
       %h2.text-center=t("preferences.languages")
-      .row.col-languages
-        - Project::LANGUAGES.in_groups(6, '') do |col_form| p col_form
-          .col-xs-6.col-sm-4.col-md-2
-            = form.simple_fields_for :skills, col_form.map{|l| Skill.new(:language => l)} do |skill_form|
-              - language = skill_form.object.language
-              .col-md-12
-                - if !language.empty?
-                  %label.language-checkbox
-                    = skill_form.check_box :language, {:id => language, :checked => current_user.skills.map(&:language).include?(language)}, language
-                    = language
-                - else
-                  .xs-space
+      .row
+        - Project::LANGUAGES.in_groups(2, '') do |main_col|
+          .col-xs-6.col-languages
+            - main_col.in_groups(3, '') do |col_form|
+              .col-xs-12.col-md-4
+                = form.simple_fields_for :skills, col_form.map{|l| Skill.new(:language => l)} do |skill_form|
+                  - language = skill_form.object.language
+                  - if !language.empty?
+                    %label.language-checkbox
+                      = skill_form.check_box :language, {:id => language, :checked => current_user.skills.map(&:language).include?(language)}, language
+                      = language
+                  - else
+                    .xs-space
     .form-group
       .col-sm-12.text-center
         - if current_user.needs_setup?

--- a/app/views/dashboards/preferences.html.haml
+++ b/app/views/dashboards/preferences.html.haml
@@ -24,18 +24,16 @@
     .col-md-12
       %h2.text-center=t("preferences.languages")
       .row
-        - Project::LANGUAGES.in_groups(2, '') do |main_col|
-          .col-xs-6.col-languages
-            - main_col.in_groups(3, '') do |col_form|
+        - Project::LANGUAGES.in_groups(2, false) do |main_col|
+          .col-xs-12.col-sm-6
+            - main_col.in_groups(3, false) do |col_form|
               .col-xs-12.col-md-4
                 = form.simple_fields_for :skills, col_form.map{|l| Skill.new(:language => l)} do |skill_form|
                   - language = skill_form.object.language
-                  - if !language.empty?
+                  .col-md-12
                     %label.language-checkbox
                       = skill_form.check_box :language, {:id => language, :checked => current_user.skills.map(&:language).include?(language)}, language
                       = language
-                  - else
-                    .xs-space
     .form-group
       .col-sm-12.text-center
         - if current_user.needs_setup?


### PR DESCRIPTION
Fix #1057.

In this PR I'm trying to improve the [/preferences](http://24pullrequests.com/preferences) page with columns in alphabetical order.

I don't have huge experience with ruby on rails,
so, let me know if we can improve something here. :)

![screenshot 2015-12-07 17-40-11](https://cloud.githubusercontent.com/assets/3224086/11637660/c946cc9a-9d09-11e5-9945-77c5c35bdafd.png)
