### PR TITLE
Fixed grammatical errors in the reminder emails

### DIFF
--- a/app/views/reminder_mailer/_mail_content.html.haml
+++ b/app/views/reminder_mailer/_mail_content.html.haml
@@ -8,7 +8,7 @@
   - else
     day left until Christmas!
 
-%p We've got some suggested projects for you to send pull requests to this #{this_time}.
+%p We've got some suggested projects for you to send pull requests to #{this_time}.
 
 %p
   - if @user.pull_requests.year(CURRENT_YEAR).any?

--- a/app/views/reminder_mailer/weekly.html.haml
+++ b/app/views/reminder_mailer/weekly.html.haml
@@ -1,1 +1,1 @@
-= render 'reminder_mailer/mail_content', this_time: 'week', next_time: 'next week'
+= render 'reminder_mailer/mail_content', this_time: 'this week', next_time: 'next week'

--- a/app/views/reminder_mailer/weekly.text.erb
+++ b/app/views/reminder_mailer/weekly.text.erb
@@ -1,1 +1,1 @@
-<%= render 'reminder_mailer/mail_content', this_time: 'week', next_time: 'next week'  %>
+<%= render 'reminder_mailer/mail_content', this_time: 'this week', next_time: 'next week'  %>

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -51,7 +51,7 @@ describe ReminderMailer, type: :mailer do
 
     it_behaves_like :reminder_mailer,
       subject: '[24 Pull Requests] Weekly Reminder',
-      this_time: 'week',
+      this_time: 'this week',
       next_time: 'next week'
   end
 end


### PR DESCRIPTION
Hey :wave: 

I noticed there were some inconsistencies and grammatical errors in the reminder emails.

The daily HTML email had:

```
We've got some suggested projects for you to send pull requests to this today.
```

and the weekly text email had:

```
We've got some suggested projects for you to send pull requests to week.
```

This PR should correct these to read as `requests to today` and `requests to this week` respectively.

Hope this is all ok.

Thanks,
.FxN