### PR TITLE
add meta_request gem to support RailsPanel Chrome extension

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development do
   gem 'thin'
   gem 'rubocop', require: false
   gem 'web-console'
+  gem 'meta_request'
 end
 
 group :development, :test, :cucumber do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
     bugsnag (2.8.13)
       json (~> 1.7, >= 1.7.7)
     builder (3.2.2)
+    callsite (0.0.11)
     capybara (2.5.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -133,6 +134,7 @@ GEM
     foreman (0.78.0)
       thor (~> 0.19.1)
     geocoder (1.2.12)
+    git-version-bump (0.15.1)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     gmaps4rails (2.1.2)
@@ -200,6 +202,10 @@ GEM
     memcachier (0.0.2)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
+    meta_request (0.3.4)
+      callsite (~> 0.0, >= 0.0.11)
+      rack-contrib (~> 1.1)
+      railties (>= 3.0.0, < 5.0.0)
     mime-types (2.6.2)
     mini_portile2 (2.0.0)
     minitest (5.8.3)
@@ -253,6 +259,9 @@ GEM
     rack-canonical-host (0.1.0)
       addressable
       rack (~> 1.0)
+    rack-contrib (1.4.0)
+      git-version-bump (~> 0.15)
+      rack (~> 1.4)
     rack-google-analytics (1.2.0)
       actionpack
       activesupport
@@ -456,6 +465,7 @@ DEPENDENCIES
   launchy
   lodash-rails
   memcachier
+  meta_request
   mime-types (= 2.6.2)
   newrelic_rpm
   octicons-rails


### PR DESCRIPTION
- This adds the `meta_request` gem in `development` environment which is required to use the [RailsPanel](https://chrome.google.com/webstore/detail/railspanel/gjpfobpafnhjhbajcjgccbbdofdckggg) Chrome extension.

Check it out, it's really cool and definitely made debugging a bit more pleasant for me! :smile: 

@andrew @jasnow 