### PR TITLE
Project suggestion autofill

### DIFF
--- a/app/assets/javascripts/bootstrap.js.coffee
+++ b/app/assets/javascripts/bootstrap.js.coffee
@@ -1,3 +1,12 @@
+window.languageAutocomplete = ->
+  return false if !$("[data-provide=typeahead]").length
+
+  projectLanguages = $("[data-provide=typeahead]").data "source"
+
+  $("[data-provide=typeahead]").typeahead
+    name: $(this).attr "name"
+    local: projectLanguages
+
 jQuery ->
   $("a[rel=popover]").popover()
   $(".tooltip").tooltip()
@@ -9,14 +18,4 @@ jQuery ->
     e.preventDefault()
     $(this).tab "show"
 
-
-  languageAutocomplete = ->
-    return false if !$("[data-provide=typeahead]").length
-
-    projectLanguages = $("[data-provide=typeahead]").data "source"
-
-    $("[data-provide=typeahead]").typeahead
-      name: $(this).attr "name"
-      local: projectLanguages
-
-  languageAutocomplete()
+    languageAutocomplete()

--- a/app/assets/javascripts/project_autofill.js
+++ b/app/assets/javascripts/project_autofill.js
@@ -1,0 +1,67 @@
+$(document).on('ready', function(){
+  var text       = 'Fill out the form from the github repo',
+      button     = $('<a href="#">' + text + '</a>'),
+      form       = $('form#new_project[action="/projects"]'),
+      github_url = form.find('#project_github_url');
+
+  github_url.after(button);
+
+  github_url.on('keydown', function(e) {
+    if (e.keyCode == 13 && $.trim($(this).val()) !== '') {
+      e.preventDefault();
+      button.trigger('click');
+    }
+  });
+
+  button.on('click', function(e){
+    e.preventDefault();
+
+    button.text('Loading...');
+
+    var req = $.ajax({
+      url: '/projects/autofill',
+      method: 'GET',
+      dataType: 'JSON',
+      data: {
+        repo: github_url.val()
+      }
+    });
+
+    req.success(function(data){
+      github_url.val(data.repository.html_url);
+      form.find('#project_name').val(data.repository.name);
+      form.find('#project_description').val(data.repository.description);
+      form.find('#project_main_language').val(data.repository.language);
+
+      // This version of typeahead has been deprecated in
+      // more recent versions of bootrap
+      // So to set the value here, I have to re-initialize
+      // the plugin again afer setting the value!
+      languageAutocomplete();
+
+      if (data.labels) {
+        form.find('.project_labels input').prop('checked', false);
+
+        form.find('.project_labels label').each(function(){
+          if ($.inArray($(this).text(), data.labels) > 0) {
+            $(this).find('input').prop('checked', true);
+          }
+        })
+      }
+
+      if (data.repo_exists) {
+        alert('Repository already suggested');
+      }
+    });
+
+    req.fail(function(res){
+      if (res.responseJSON && res.responseJSON.message) {
+        alert(res.responseJSON.message);
+      }
+    });
+
+    req.complete(function(data){
+      button.text(text);
+    });
+  });
+});

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -70,7 +70,16 @@ class ProjectsController < ApplicationController
     respond_with @projects
   end
 
+  def autofill
+    request = repo_with_labels(params[:repo])
+    render json: request[:data], status: request[:status]
+  end
+
   protected
+
+  def repo_with_labels(url)
+    RepoWithLabels.new(current_user.github_client, url).call
+  end
 
   def current_user_languages
     @current_user_languages ||= begin

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -22,6 +22,10 @@ class GithubClient
     client.repo(repository)
   end
 
+  def labels(repository)
+    client.labels(repository)
+  end
+
   def issues(repository, options = {})
     client.issues(repository, options)
   end

--- a/app/services/repo_with_labels.rb
+++ b/app/services/repo_with_labels.rb
@@ -1,0 +1,46 @@
+class RepoWithLabels
+  attr_reader :client, :name
+
+  def initialize(client, name)
+    @client = client
+    @name   = name.split('github.com/').last
+  end
+
+  def call
+    res = fetch_repo
+
+    if res[:status] == 200
+      res[:data][:repo_exists] = repo_exists?(res)
+      res[:data][:labels]      = fetch_labels
+    end
+
+    res
+  end
+
+  private
+
+  def repo_exists?(res)
+    Project.exists?(github_url: res[:data][:repository][:html_url])
+  end
+
+  def fetch_repo
+    # We need to make sure the Sawyer::Resource is transformed
+    # into a hash else rails will turn the {foo: bar} into a
+    # [['foo', 'bar']] when sending it in a JSON response
+    response({ repository: client.repository(name).to_hash }, 200)
+  rescue Octokit::InvalidRepository
+    response({ message: 'Invalid repository' }, 422)
+  rescue Octokit::NotFound
+    response({ message: 'Repo not found' }, 404)
+  rescue Octokit::TooManyRequests
+    response({ message: 'Too many requests' }, 403)
+  end
+
+  def fetch_labels
+    client.labels(name).map { |e| e['name'] }
+  end
+
+  def response(data, status)
+    { data: data, status: status }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Tfpullrequests::Application.routes.draw do
   resources :projects, only: [:index, :new, :create, :edit, :update, :destroy] do
     collection do
       get :filter
+      get :autofill
       post :claim
     end
   end

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -44,7 +44,7 @@ describe GithubClient do
   end
 
   describe '#issues' do
-    it "returns a repository's issues" do
+    it "returns a repositories issues" do
       repository = 'some-repository'
       expect(client).to receive(:issues).with(repository, {})
 
@@ -53,11 +53,29 @@ describe GithubClient do
   end
 
   describe '#commits' do
-    it "returns a repository's commits" do
+    it "returns a repositories commits" do
       repository = 'some-repository'
       expect(client).to receive(:commits).with(repository, {})
 
       github_client.commits(repository, {})
+    end
+  end
+
+  describe '#repository' do
+    it "returns a repository" do
+      repository = '24pullrequests/24pullrequests'
+      expect(client).to receive(:repo).with(repository)
+
+      github_client.repository(repository)
+    end
+  end
+
+  describe '#labels' do
+    it "returns a repositories labels" do
+      repository = '24pullrequests/24pullrequests'
+      expect(client).to receive(:labels).with(repository)
+
+      github_client.labels(repository)
     end
   end
 end

--- a/spec/services/repo_with_labels_spec.rb
+++ b/spec/services/repo_with_labels_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+describe RepoWithLabels do
+  let(:client) do
+    instance_double('GithubClient')
+  end
+
+  describe '#repo' do
+    it 'Repository with name' do
+      res = described_class.new(client, 'foo/bar')
+      expect(res.name).to eq('foo/bar')
+    end
+
+    it 'Repository with github url' do
+      res = described_class.new(client, 'http://github.com/foo/bar')
+      expect(res.name).to eq('foo/bar')
+    end
+  end
+
+  describe '#call' do
+    let(:res) do
+      described_class.new(client, 'foo/bar')
+    end
+
+    it 'successful' do
+      # This tests that to_hash is called
+      data = instance_double('Sawyer::Resource', to_hash: {
+        html_url: 'https://github.com/foo/bar' })
+
+      allow(client).to receive(:repository).with('foo/bar')
+        .and_return(data)
+
+      allow(client).to receive(:labels).and_return([
+        { "name" => 'foo' },
+        { "name" => 'bar' }
+      ])
+
+      allow(Project).to receive(:exists?)
+        .with(github_url: 'https://github.com/foo/bar')
+        .and_return(true)
+
+      expect(res.call.as_json).to eq({
+        'data' => {
+          'repository' => {
+            'html_url' => 'https://github.com/foo/bar'
+          },
+          'labels' => %w(foo bar),
+          'repo_exists' => true
+        },
+        'status' => 200
+      })
+    end
+
+    # Test to make sure it doesnt error
+    it 'successful but no html_url' do
+      data = instance_double('Sawyer::Resource', to_hash: {
+        foo: 'bar' })
+
+      allow(client).to receive(:repository).with('foo/bar')
+        .and_return(data)
+
+      allow(client).to receive(:labels).and_return([
+        { "name" => 'foo' },
+        { "name" => 'bar' }
+      ])
+
+      expect(res.call.as_json).to eq({
+        'data' => {
+          'repository' => {
+            'foo' => 'bar'
+          },
+          'labels' => %w(foo bar),
+          'repo_exists' => false
+        },
+        'status' => 200
+      })
+    end
+
+    it 'InvalidRepository' do
+      allow(client).to receive(:repository)
+        .and_raise(Octokit::InvalidRepository)
+
+      expect(res.call.as_json).to eq({
+        'data' => { 'message' => 'Invalid repository' },
+        'status' => 422 })
+    end
+
+    it 'NotFound' do
+      allow(client).to receive(:repository)
+        .and_raise(Octokit::NotFound)
+
+      expect(res.call.as_json).to eq({
+        'data' => { 'message' => 'Repo not found' },
+        'status' => 404 })
+    end
+
+    it 'TooManyRequests' do
+      allow(client).to receive(:repository)
+        .and_raise(Octokit::TooManyRequests)
+
+      expect(res.call.as_json).to eq({
+        'data' => { 'message' => 'Too many requests' },
+        'status' => 403 })
+    end
+  end
+end


### PR DESCRIPTION
In #1001 @caioproiete mentioned

> Of course, in an ideal world, after putting the URL of the GitHub project, all the labels for that project should be fetched and we should be able to select the ones we want to promote, but this can be for another issue ;).

It doesn't solve the custom label problem but it does mean less manual form filling if you so choose :smile:

Have a play/test and see if you like it. It should work without any ENV keys specified, but you might get rate limited fairly quickly.