### PR TITLE
Hide past events

### DIFF
--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -65,6 +65,17 @@ class Map
 
 $ ->
 
+  $('.toggle-past-events').click (evt) =>
+    pastEvents = $('.past-events')
+    spanTxt = $('.toggle-past-events').children('span')
+
+    if pastEvents.hasClass('hidden')
+      pastEvents.removeClass('hidden')
+      spanTxt.text('Hide')
+    else
+      pastEvents.addClass('hidden')
+      spanTxt.text('Show')
+
   allowTimes =  []
   for hour in [0..23]
     for quarter in ["00", "15", "30", "45"]

--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -65,17 +65,6 @@ class Map
 
 $ ->
 
-  $('.toggle-past-events').click (evt) =>
-    pastEvents = $('.past-events')
-    spanTxt = $('.toggle-past-events').children('span')
-
-    if pastEvents.hasClass('hidden')
-      pastEvents.removeClass('hidden')
-      spanTxt.text('Hide')
-    else
-      pastEvents.addClass('hidden')
-      spanTxt.text('Show')
-
   allowTimes =  []
   for hour in [0..23]
     for quarter in ["00", "15", "30", "45"]
@@ -104,3 +93,15 @@ $ ->
           element: @
         )
         map.map.addOverlay(overlay)
+
+  if $('.toggle-past-events').length
+    $('.toggle-past-events').click (evt) =>
+      pastEvents = $('.past-events')
+      spanTxt = $('.toggle-past-events').children('span')
+
+      if pastEvents.hasClass('hidden')
+        pastEvents.removeClass('hidden')
+        spanTxt.text('Hide')
+      else
+        pastEvents.addClass('hidden')
+        spanTxt.text('Show')

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -19,10 +19,14 @@
           = link_to "", event, class: "pin", data: { latitude: event.latitude, longitude: event.longitude }
     .col-sm-12.col-md-6
       = render @upcoming_events
-
 - unless @past_events.empty?
   %hr
-  %h4 Past 24 Pull Requests Events
   .row
+    %p
+      %button.btn.btn-default.toggle-past-events
+        %span Show
+        Past 24 Pull Requests Events
+  .row.past-events.hidden
+    %h4 Past 24 Pull Requests Events
     .col-md-12
       = render @past_events


### PR DESCRIPTION
Added a button to show/hide past events, fix #990.

It's just a suggestion, we can think together in another solution for hide the past events.

![screenshot-2015-12-09-at-22 56 50](https://cloud.githubusercontent.com/assets/3224086/11703975/b0e0bd74-9eca-11e5-80ba-29021b9fc3e3.png)
![screenshot-2015-12-09-at-22 57 05](https://cloud.githubusercontent.com/assets/3224086/11703976/b2d9e3c6-9eca-11e5-8d1d-d87dc21a3409.png)
