### PR TITLE
Format spec output as a christmas tree

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,4 @@
 --color
 --require spec_helper
+--require christmas_tree_formatter
+--format ChristmasTreeFormatter

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :development, :test, :cucumber do
   gem 'webmock', require: false
   gem 'timecop'
   gem 'simplecov'
+  gem 'christmas_tree_formatter'
 
   # Javascript
   gem 'konacha'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
     chai-jquery-rails (2.0.0)
       railties (>= 3.1)
       sprockets
+    christmas_tree_formatter (0.1.0)
+      rspec-core (~> 3.0)
     cliver (0.3.2)
     codeclimate-test-reporter (0.4.8)
       simplecov (>= 0.7.1, < 1.0.0)
@@ -445,6 +447,7 @@ DEPENDENCIES
   brakeman
   bugsnag
   chai-jquery-rails
+  christmas_tree_formatter
   codeclimate-test-reporter
   coffee-rails
   coveralls


### PR DESCRIPTION
![screen shot 2015-12-10 at 11 23 56 am](https://cloud.githubusercontent.com/assets/1060/11714231/996a4b68-9f30-11e5-8f56-c8e42aac32f6.png)

Uses this gem https://libraries.io/rubygems/christmas_tree_formatter

:christmas_tree: 