### PR TITLE
Add default values to latitude and longitude on events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,6 @@
 class Event < ActiveRecord::Base
   belongs_to :user
-  validates :name, :location, :url, :start_time, :latitude, :longitude, :description, presence: true
+  validates :name, :location, :url, :start_time, :description, presence: true
   validates :url, format: URI.regexp(%w(http https))
   validate :validate_start_time_is_in_range, if: :start_time
   validate :validate_start_time_is_not_in_the_past, if: :start_time

--- a/db/migrate/20151210211153_add_defaults_event_lat_lng.rb
+++ b/db/migrate/20151210211153_add_defaults_event_lat_lng.rb
@@ -1,0 +1,11 @@
+class AddDefaultsEventLatLng < ActiveRecord::Migration
+  def up
+    change_column_default :events, :latitude, 0.0
+    change_column_default :events, :longitude, 0.0
+  end
+
+  def down
+    change_column_default :events, :latitude, nil
+    change_column_default :events, :longitude, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151127190033) do
+ActiveRecord::Schema.define(version: 20151210211153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,10 +34,10 @@ ActiveRecord::Schema.define(version: 20151127190033) do
     t.string   "location"
     t.string   "url"
     t.datetime "start_time"
-    t.decimal  "latitude",    precision: 10, scale: 6
-    t.decimal  "longitude",   precision: 10, scale: 6
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+    t.decimal  "latitude",    precision: 10, scale: 6, default: 0.0
+    t.decimal  "longitude",   precision: 10, scale: 6, default: 0.0
+    t.datetime "created_at",                                         null: false
+    t.datetime "updated_at",                                         null: false
     t.text     "description"
     t.integer  "user_id"
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -5,9 +5,10 @@ describe Event, type: :model do
   it { is_expected.to validate_presence_of(:location) }
   it { is_expected.to validate_presence_of(:url) }
   it { is_expected.to validate_presence_of(:start_time) }
-  it { is_expected.to validate_presence_of(:latitude) }
-  it { is_expected.to validate_presence_of(:longitude) }
   it { is_expected.to validate_presence_of(:description) }
+
+  it { is_expected.to have_db_column(:latitude).with_options(default: 0.0) }
+  it { is_expected.to have_db_column(:longitude).with_options(default: 0.0) }
 
   context 'validations' do
     let(:event) { FactoryGirl.build(:event) }


### PR DESCRIPTION
Fixes #968 annoyingly I couldn't recreate the bug today but it makes sense to default the values to 0 anyway because that is what blocking the geolocation does and you can still create an event with those values.