### PR TITLE
Emoji string replacement

### DIFF
--- a/app/assets/javascripts/bootstrap.js.coffee
+++ b/app/assets/javascripts/bootstrap.js.coffee
@@ -20,4 +20,5 @@ jQuery ->
 
     languageAutocomplete()
 
-  Emojify.replace('.js-emoji');
+$(document).on 'ready page:load', ->
+  Emojify.replace '.js-emoji'

--- a/app/assets/javascripts/bootstrap.js.coffee
+++ b/app/assets/javascripts/bootstrap.js.coffee
@@ -19,3 +19,5 @@ jQuery ->
     $(this).tab "show"
 
     languageAutocomplete()
+
+  Emojify.replace('.js-emoji');

--- a/app/assets/javascripts/dashboard.js.coffee
+++ b/app/assets/javascripts/dashboard.js.coffee
@@ -12,5 +12,5 @@ $ ->
         $('#pull-requests').html(data)
         $('#pull-requests-count').html $('.pull_request').length
         $("#spinner, #search_button").toggle()
-        emojify()
+        $(document).trigger('page:load')
         $('abbr.timeago').timeago()

--- a/app/assets/javascripts/emoji.js
+++ b/app/assets/javascripts/emoji.js
@@ -1,0 +1,101 @@
+Emojify = {
+  replace: function(selector) {
+    $(selector).each(function(){
+      Emojify._updateNode(this);
+    });
+  },
+
+  _updateNode: function(node) {
+    if (!Emojify._replace(node.textContent).match(/\[:\w+:\]/m))
+      return;
+
+    for (var i = 0; i < node.childNodes.length; i++) {
+      var n = node.childNodes[i];
+
+      if (n.nodeName == '#text') {
+        var newNode = document.createElement('span');
+
+        Emojify._splitEmo(Emojify._replace(n.textContent)).forEach(function(e){
+          newNode.appendChild(e);
+        });
+
+        n.parentNode.replaceChild(newNode, n);
+      }
+    }
+  },
+
+  _createEmojiNode: function(text) {
+    var node = document.createElement('div');
+    node.innerHTML = emojione.shortnameToImage(text);
+    return node.childNodes[0];
+  },
+
+  _splitEmo: function(str) {
+    return str.split(/(\[:\w+:\])/gm).map(function(e){
+      if (e.match(/^\[:\w+:\]$/))
+        return Emojify._createEmojiNode(e.replace(/(\[|\])/, ''));
+
+      return document.createTextNode(e);
+    })
+  },
+
+  _replace: function(str) {
+    str = Emojify._replace_at_start(str);
+    str = Emojify._replace_at_end(str);
+    str = Emojify._replace_whole_line(str);
+    str = Emojify._replace_with_spaces_around(str);
+    return str;
+  },
+
+  _replace_at_start: function(str) {
+    var r = /^(:\w+:) /m
+
+    if (!str.match(r))
+      return str;
+
+    str = str.replace(r, function(e){
+      return '[' + e.trim() + '] ';
+    });
+
+    return Emojify._replace_at_start(str);
+  },
+
+  _replace_at_end: function(str) {
+    var r = / (:\w+:)$/m
+
+    if (!str.match(r))
+      return str;
+
+    str = str.replace(r, function(e){
+      return ' [' + e.trim() + '] ';
+    });
+
+    return Emojify._replace_at_end(str);
+  },
+
+  _replace_whole_line: function(str) {
+    var r = /^(:\w+:)$/m
+
+    if (!str.match(r))
+      return str;
+
+    str = str.replace(r, function(e){
+      return '[' + e.trim() + ']';
+    });
+
+    return Emojify._replace_whole_line(str);
+  },
+
+  _replace_with_spaces_around: function(str) {
+    var r = / (:\w+:) /m
+
+    if (!str.match(r))
+      return str;
+
+    str = str.replace(r, function(e){
+      return ' [' + e.trim() + '] ';
+    });
+
+    return Emojify._replace_with_spaces_around(str);
+  }
+};

--- a/app/assets/javascripts/emoji.js
+++ b/app/assets/javascripts/emoji.js
@@ -6,7 +6,7 @@ Emojify = {
   },
 
   _updateNode: function(node) {
-    if (!Emojify._replace(node.textContent).match(/\[:\w+:\]/m))
+    if (!Emojify._replace($(node).text()).match(/\[:\w+:\]/m))
       return;
 
     for (var i = 0; i < node.childNodes.length; i++) {
@@ -15,11 +15,11 @@ Emojify = {
       if (n.nodeName == '#text') {
         var newNode = document.createElement('span');
 
-        Emojify._splitEmo(Emojify._replace(n.textContent)).forEach(function(e){
+        $.each(Emojify._splitEmo(Emojify._replace($(n).text())), function(i, e){
           newNode.appendChild(e);
         });
 
-        n.parentNode.replaceChild(newNode, n);
+        $(n).replaceWith(newNode);
       }
     }
   },
@@ -31,7 +31,7 @@ Emojify = {
   },
 
   _splitEmo: function(str) {
-    return str.split(/(\[:\w+:\])/gm).map(function(e){
+    return $.map(str.split(/(\[:\w+:\])/gm), function(e){
       if (e.match(/^\[:\w+:\]$/))
         return Emojify._createEmojiNode(e.replace(/(\[|\])/, ''));
 
@@ -54,7 +54,7 @@ Emojify = {
       return str;
 
     str = str.replace(r, function(e){
-      return '[' + e.trim() + '] ';
+      return '[' + $.trim(e) + '] ';
     });
 
     return Emojify._replace_at_start(str);
@@ -67,7 +67,7 @@ Emojify = {
       return str;
 
     str = str.replace(r, function(e){
-      return ' [' + e.trim() + '] ';
+      return ' [' + $.trim(e) + '] ';
     });
 
     return Emojify._replace_at_end(str);
@@ -80,7 +80,7 @@ Emojify = {
       return str;
 
     str = str.replace(r, function(e){
-      return '[' + e.trim() + ']';
+      return '[' + $.trim(e) + ']';
     });
 
     return Emojify._replace_whole_line(str);
@@ -93,7 +93,7 @@ Emojify = {
       return str;
 
     str = str.replace(r, function(e){
-      return ' [' + e.trim() + '] ';
+      return ' [' + $.trim(e) + '] ';
     });
 
     return Emojify._replace_with_spaces_around(str);

--- a/app/assets/javascripts/emoji.js.coffee
+++ b/app/assets/javascripts/emoji.js.coffee
@@ -1,5 +1,0 @@
-window.emojify = ->
-  $(".js-emoji").each ->
-    # $(@).html(emojione.toImage($(@).text()))
-
-$ -> emojify()

--- a/app/assets/javascripts/str_split.js
+++ b/app/assets/javascripts/str_split.js
@@ -1,0 +1,43 @@
+/*
+ * https://gist.github.com/bbogovich/2611473
+ * String.split(delimiter,limit)
+ * Override Internet Explorer implementation of String.split to handle regular
+ * expression capture groups in the same manner as all other browsers.  Each
+ * capture group in the matched text will be included in the split array.
+ */
+if("a'b".split(/(')/g).length==2){
+  String.prototype.split = function(delimiter/*,limit*/){
+    if(typeof(delimiter)=="undefined"){
+      return [this];
+    }
+    var limit = arguments.length>1?arguments[1]:-1;
+    var result = [];
+    if(delimiter.constructor==RegExp){
+      delimiter.global = true;
+      var regexpResult,str=this,previousIndex = 0;
+      while(regexpResult = delimiter.exec(str)){
+        result.push(str.substring(previousIndex,regexpResult.index))
+        for (var captureGroup=1,ct=regexpResult.length;captureGroup<ct;captureGroup++){
+          result.push(regexpResult[captureGroup]);
+        }
+        str=str.substring(delimiter.lastIndex,str.length);
+      }
+      result.push(str);
+    }else{
+      var searchIndex=0,foundIndex=0,len=this.length,dlen=delimiter.length;
+      while(foundIndex!=-1){
+        foundIndex = this.indexOf(delimiter,searchIndex);
+        if(foundIndex!=-1){
+          result.push(this.substring(searchIndex,foundIndex))
+          searchIndex = foundIndex+dlen;
+        }else{
+          result.push(this.substring(searchIndex,len));
+        }
+      }
+    }
+    if(arguments.length>1&&result.length>limit){
+      result = result.slice(0,limit);
+    }
+    return result;
+  }
+}

--- a/spec/javascripts/emojify_spec.js
+++ b/spec/javascripts/emojify_spec.js
@@ -46,4 +46,11 @@ describe('Emojify', function(){
     Emojify.replace(node);
     expect(node.html()).to.eq('::Session::');
   });
+
+  it('Run twice', function(){
+    var node = $('<p>:smile:</p>');
+    Emojify.replace(node);
+    Emojify.replace(node);
+    expect(node.html()).to.eq('<span>' + smile + '</span>');
+  });
 });

--- a/spec/javascripts/emojify_spec.js
+++ b/spec/javascripts/emojify_spec.js
@@ -1,0 +1,49 @@
+//= require jquery
+//= require emojione
+//= require emoji
+
+var smile = '<img class="emojione" alt="😄" src="//cdn.jsdelivr.net/emojione/assets/png/1F604.png?v=1.2.4">';
+
+describe('Emojify', function(){
+  it('simple', function(){
+    var node = $('<p>:smile:</p>');
+    Emojify.replace(node);
+    expect(node.html()).to.eq('<span>' + smile + '</span>');
+  });
+
+  it('simple', function(){
+    var node = $('<p>:smile:\n:smile:</p>');
+    Emojify.replace(node);
+    expect(node.html()).to.eq('<span>' + smile + '\n' + smile + '</span>');
+  });
+
+  it('simple with words', function(){
+    var node = $('<p>foo :smile: foo</p>');
+    Emojify.replace(node);
+    expect(node.html()).to.eq('<span>foo ' + smile + ' foo</span>');
+  });
+
+  it('keep escaped html', function(){
+    var node = $('<p>:smile: &lt;select&gt;</p>');
+    Emojify.replace(node);
+    expect(node.html()).to.eq('<span>' + smile + ' &lt;select&gt;</span>');
+  });
+
+  it('no emojies', function(){
+    var node = $('<p>foo</p>');
+    Emojify.replace(node);
+    expect(node.html()).to.eq('foo');
+  });
+
+  it('Colons!', function(){
+    var node = $('<p>Rack::Session::Cookie :sessions. Resolves: #2492</p>');
+    Emojify.replace(node);
+    expect(node.html()).to.eq('Rack::Session::Cookie :sessions. Resolves: #2492');
+  });
+
+  it('Double colons start and end', function(){
+    var node = $('<p>::Session::</p>');
+    Emojify.replace(node);
+    expect(node.html()).to.eq('::Session::');
+  });
+});


### PR DESCRIPTION
Adds emoji back #1108 :relieved:

It loops through the child nodes and splits up text nodes which have emoji in them, inserting the image only where it needs instead of replacing the whole html string so it doesn't accidently convert any escaped html strings.

I found many edge cases to the simple regex when I was writing the tests, so it recursively replaces items it finds in the string instead of using one magical regex because I'm not that smart! Let me know if you're a regex guru and can simplify it.

Fixes the need to disable the emoji replacement here #919 9d62d920d8346f6a278b95923345e0e969ac3a50