### PR TITLE
Fix typo

### DIFF
--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -17,4 +17,4 @@
     - if @event.can_edit?(current_user)
       %hr
       = link_to t("events.show.edit_event"), edit_event_path(@event), class: "btn btn-default"
-      = link_to t("events.show.destroy_event"), @event, data: { confirm: "event.show.confirm_destroy" }, method: :delete, class: "btn btn-danger"
+      = link_to t("events.show.destroy_event"), @event, data: { confirm: I18n.t("events.show.confirm_destroy") }, method: :delete, class: "btn btn-danger"


### PR DESCRIPTION
"event.show.confirm_destroy" -> I18n.t("events.show.confirm_destroy")

before
<img width="1440" alt="before2" src="https://cloud.githubusercontent.com/assets/1207985/11822390/ace6a7ec-a3b1-11e5-851b-6b1e56a67032.png">

after
<img width="1440" alt="after2" src="https://cloud.githubusercontent.com/assets/1207985/11822404/c121ce12-a3b1-11e5-88d5-15263e40a247.png">
