### PR TITLE
Update ruby version installed by Ansible to match Gemfile

### DIFF
--- a/ansible/roles/ruby/tasks/main.yml
+++ b/ansible/roles/ruby/tasks/main.yml
@@ -8,5 +8,5 @@
 - name: Install Ruby 2.1
   apt: pkg={{ item }} state=latest
   with_items:
-    - ruby2.1
-    - ruby2.1-dev
+    - ruby2.2
+    - ruby2.2-dev


### PR DESCRIPTION
This fixes #1058, bringing Ansible's set up back in line with the Gemfile.

Without this, the local Vagrant setup is currently broken (until you follow the manual steps in that issue). With this, it magically works.