### PR TITLE
Update docs to start vagrant server locally on 0.0.0.0, not just localhost

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Once the process is completed, you need to log in, by running:
 There's no need to provide login or password. Now go to the project directory inside the VM in order to run the rails server:
 
     $ cd /vagrant
-    $ bundle exec rails s
+    $ bundle exec rails s -b 0.0.0.0
 
 This will initialize the development Rails server.
 Now you can go to your regular browser, in the Host machine (your main OS) and access the application through the address `http://192.168.12.34:3000`.

--- a/Readme.md
+++ b/Readme.md
@@ -110,7 +110,7 @@ is finished, log in to run the rails dev server:
 
     $ vagrant ssh
     $ cd /vagrant
-    $ bundle exec rails s
+    $ bundle exec rails s -b 0.0.0.0
 
 Then you should be able to access the application through your regular browser at http://192.168.12.34:3000.
 


### PR DESCRIPTION
[With Rails 4.2](https://fullstacknotes.com/make-rails-4-2-listen-to-all-interface/) this is no longer the default, but it's required for vagrant-based development to let you access the server from the host machine. Without this the "access the application through the address http://192.168.12.34:3000" step doesn't work.

We could make this the default for running in development all the time, but it's plausibly a small security risk (exposing an extra service), and it's unlikely you'll ever want it for development outside vagrant anyway.