### PR TITLE
Make sure that nils cannot appear in the active_users list

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -14,8 +14,6 @@ class StaticController < ApplicationController
     # available on their profile when authenticating with the site
     @map_markers = Rails.cache.fetch 'contributors-map-markers', expires_in: 24.hours do
       Gmaps4rails.build_markers(active_users) do |user, marker|
-        next if user.nil? || user.lat.nil? || user.lng.nil?
-
         marker.lat user.lat
         marker.lng user.lng
       end.reject { |m| m.empty? }
@@ -33,6 +31,6 @@ class StaticController < ApplicationController
 
   # Currently-active contributors, i.e. users with a pull request this year
   def active_users
-    PullRequest.year(current_year).map(&:user).uniq
+    PullRequest.active_users(current_year)
   end
 end

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -15,6 +15,10 @@ class PullRequest < ActiveRecord::Base
   LATEST_PULL_DATE   = Date.parse("25/12/#{CURRENT_YEAR}").midnight
 
   class << self
+    def active_users(year)
+      PullRequest.includes(:user).year(year).map(&:user).uniq.compact
+    end
+
     def create_from_github(json)
       create(initialize_from_github(json))
     end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -66,10 +66,15 @@ describe PullRequest, type: :model do
   end
 
   context '#scopes' do
+    let(:user) do
+      create :user, nickname: 'foo'
+    end
+
     let!(:pull_requests) do
       4.times.map  do |n|
         create(:pull_request, language:   'Haskell',
-                              created_at: DateTime.now + n.minutes)
+                              created_at: DateTime.now + n.minutes,
+                              user: user)
       end
     end
 
@@ -81,5 +86,16 @@ describe PullRequest, type: :model do
       expect(PullRequest.latest(3)).to eq(pull_requests.reverse.take(3))
     end
 
+    describe '#active_users' do
+      it 'Find users' do
+        expect(PullRequest.active_users(2015).map(&:nickname)).to eq(%w(foo))
+      end
+
+      it 'Prevent nils' do
+        nil_user = double('PullRequest', user: nil)
+        allow(PullRequest).to receive(:year).and_return([nil_user, nil_user])
+        expect(PullRequest.active_users(2015)).to eq([])
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #1120 and adds test to make sure there are no nils in the users returned

Also added ```includes(:user)``` which should speed it up too.