### PR TITLE
Fix typo

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,6 +110,8 @@ en:
       you can join a hack event and code together.
     edit:
       title: Edit Suggestion
+    index:
+      host_an_event: Host an event
     new:
       form:
         description: Description

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -93,6 +93,8 @@ ja:
       you can join a hack event and code together.
     edit:
       title: Edit Suggestion
+    index:
+      host_an_event: イベントを主催する
     new:
       form:
         description: 説明


### PR DESCRIPTION
Add config "events.index.host_an_event"

before
```
<a class="btn btn-default" href="/events/new"><span class="translation_missing" title="translation missing: ja.events.index.host_an_event">Host An Event</span></a>
```
after
```
<a class="btn btn-default" href="/events/new">Host an event</a>
```