### PR TITLE
Check for user before showing the avatar

### DIFF
--- a/app/views/pull_requests/_pull_request.html.haml
+++ b/app/views/pull_requests/_pull_request.html.haml
@@ -1,6 +1,7 @@
 = cache pull_request do
   .pull_request{:class => parameterize_language(pull_request.language)}
-    = link_to image_tag(pull_request.user.avatar_url, :width => 80, :height => 80, :alt => pull_request.user.nickname), user_path(pull_request.user.nickname), :rel => 'tooltip', :data => { :original_title => pull_request.user.nickname }, :class => 'image'
+    - if pull_request.user
+      = link_to image_tag(pull_request.user.avatar_url, :width => 80, :height => 80, :alt => pull_request.user.nickname), user_path(pull_request.user.nickname), :rel => 'tooltip', :data => { :original_title => pull_request.user.nickname }, :class => 'image'
     - if pull_request.language.present?
       .language.label.label-info.pull-right
         = link_to pull_request.language, language_path(pull_request.language)

--- a/spec/requests/pull_requests_spec.rb
+++ b/spec/requests/pull_requests_spec.rb
@@ -11,4 +11,17 @@ describe 'PullRequests', type: :request do
 
     it { is_expected.to have_content '5 Pull Requests already made!' }
   end
+
+  describe 'Users' do
+    before do
+      user = create :user
+      create :pull_request, user: user
+      create :pull_request, user_id: nil
+      visit pull_requests_path
+    end
+
+    it 'Only show the image when there is a user' do
+      expect(page.all('.pull_request a.image').length).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1121

User already has ```has_many :pull_requests, dependent: :destroy```