### PR TITLE
Add pull request filtering in aggregations

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -3,7 +3,7 @@ class OrganisationsController < ApplicationController
   respond_to :js, only: :index
 
   def index
-    @organisations = Organisation.with_user_counts.order_by_pull_requests.page(params[:page])
+    @organisations = Organisation.order_by_pull_requests.page(params[:page])
     respond_with @organisations
   end
 

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -3,7 +3,7 @@ class StaticController < ApplicationController
     @projects = Project.includes(:labels).active.limit(200).sample(6)
     @featured_projects = Project.includes(:labels).featured.limit(200).sample(6)
     @users = User.order('pull_requests_count desc').limit(200).sample(24)
-    @orgs = Organisation.with_user_counts.order_by_pull_requests.limit(200).sample(24)
+    @orgs = Organisation.order_by_pull_requests.limit(200).sample(24)
     @pull_requests = PullRequest.year(current_year).order('created_at desc').limit(5)
   end
 

--- a/app/models/aggregation_filter.rb
+++ b/app/models/aggregation_filter.rb
@@ -1,0 +1,3 @@
+class AggregationFilter < ActiveRecord::Base
+  belongs_to :user
+end

--- a/app/models/aggregation_filter.rb
+++ b/app/models/aggregation_filter.rb
@@ -3,7 +3,7 @@ class AggregationFilter < ActiveRecord::Base
 
   def self.pull_request_filter
     where("pull_requests.user_id = aggregation_filters.user_id")
-    .where("pull_requests.repo_name LIKE aggregation_filters.repo_pattern")
+    .where("pull_requests.title LIKE aggregation_filters.title_pattern")
     .exists.not
   end
 end

--- a/app/models/aggregation_filter.rb
+++ b/app/models/aggregation_filter.rb
@@ -3,7 +3,7 @@ class AggregationFilter < ActiveRecord::Base
 
   def self.pull_request_filter
     where("pull_requests.user_id = aggregation_filters.user_id")
-    .where("pull_requests.title LIKE aggregation_filters.title_pattern")
+    .where("pull_requests.title ILIKE aggregation_filters.title_pattern")
     .exists.not
   end
 end

--- a/app/models/aggregation_filter.rb
+++ b/app/models/aggregation_filter.rb
@@ -1,9 +1,7 @@
 class AggregationFilter < ActiveRecord::Base
   belongs_to :user
 
-  PULL_REQUEST_SQL_FILTER = 'NOT EXISTS (
-    SELECT 1 FROM aggregation_filters filter
-    WHERE pull_requests.user_id = filter.user_id
-    AND pull_requests.repo_name LIKE filter.repo_pattern
-  )'
+  PULL_REQUEST_FILTER = AggregationFilter.where("pull_requests.user_id = aggregation_filters.user_id")
+                                         .where("pull_requests.repo_name LIKE aggregation_filters.repo_pattern")
+                                         .exists.not
 end

--- a/app/models/aggregation_filter.rb
+++ b/app/models/aggregation_filter.rb
@@ -1,7 +1,9 @@
 class AggregationFilter < ActiveRecord::Base
   belongs_to :user
 
-  PULL_REQUEST_FILTER = AggregationFilter.where("pull_requests.user_id = aggregation_filters.user_id")
-                                         .where("pull_requests.repo_name LIKE aggregation_filters.repo_pattern")
-                                         .exists.not
+  def self.pull_request_filter
+    where("pull_requests.user_id = aggregation_filters.user_id")
+    .where("pull_requests.repo_name LIKE aggregation_filters.repo_pattern")
+    .exists.not
+  end
 end

--- a/app/models/aggregation_filter.rb
+++ b/app/models/aggregation_filter.rb
@@ -1,3 +1,9 @@
 class AggregationFilter < ActiveRecord::Base
   belongs_to :user
+
+  PULL_REQUEST_SQL_FILTER = 'NOT EXISTS (
+    SELECT 1 FROM aggregation_filters filter
+    WHERE pull_requests.user_id = filter.user_id
+    AND pull_requests.repo_name LIKE filter.repo_pattern
+  )'
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,6 +1,6 @@
 class Organisation < ActiveRecord::Base
   has_and_belongs_to_many :users
-  has_many :pull_requests, -> { order('created_at desc') }, through: :users
+  has_many :pull_requests, -> { order('created_at desc').for_aggregation }, through: :users
 
   scope :order_by_pull_requests, -> do
     order('organisations.pull_request_count desc, organisations.login asc')

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -17,10 +17,6 @@ class Organisation < ActiveRecord::Base
 
       where(login: response.login).first_or_create(params)
     end
-
-    def with_user_counts
-      joins(:users).select('organisations.*, COUNT(users.id) as users_count').group('organisations.id')
-    end
   end
 
   def active_languages

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -1,7 +1,7 @@
 class PullRequest < ActiveRecord::Base
   belongs_to :user
-  after_save { user.update_pull_request_count }
-  after_destroy { user.update_pull_request_count }
+  after_save { if user then user.update_pull_request_count end }
+  after_destroy { if user then user.update_pull_request_count end }
 
   validates :issue_url, uniqueness: { scope: :user_id }
 

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -1,5 +1,7 @@
 class PullRequest < ActiveRecord::Base
-  belongs_to :user, counter_cache: true
+  belongs_to :user
+  after_save { user.update_pull_request_count }
+  after_destroy { user.update_pull_request_count }
 
   validates :issue_url, uniqueness: { scope: :user_id }
 

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -13,7 +13,7 @@ class PullRequest < ActiveRecord::Base
   scope :by_language, -> (language) { where('lower(language) = ?', language.downcase) }
   scope :latest, -> (limit) { order('created_at desc').limit(limit) }
   scope :for_aggregation, -> {
-    where(AggregationFilter::PULL_REQUEST_FILTER)
+    where(AggregationFilter.pull_request_filter)
   }
 
   EARLIEST_PULL_DATE = Date.parse("01/12/#{CURRENT_YEAR}").midnight

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -10,11 +10,8 @@ class PullRequest < ActiveRecord::Base
   scope :year, -> (year) { where('EXTRACT(year FROM "created_at") = ?', year) }
   scope :by_language, -> (language) { where('lower(language) = ?', language.downcase) }
   scope :latest, -> (limit) { order('created_at desc').limit(limit) }
-
   scope :for_aggregation, -> {
-    where(
-      'NOT EXISTS (SELECT 1 FROM aggregation_filters f WHERE pull_requests.user_id = f.user_id AND pull_requests.repo_name LIKE f.repo_pattern)'
-    )
+    where(AggregationFilter::PULL_REQUEST_SQL_FILTER)
   }
 
   EARLIEST_PULL_DATE = Date.parse("01/12/#{CURRENT_YEAR}").midnight

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -11,6 +11,12 @@ class PullRequest < ActiveRecord::Base
   scope :by_language, -> (language) { where('lower(language) = ?', language.downcase) }
   scope :latest, -> (limit) { order('created_at desc').limit(limit) }
 
+  scope :for_aggregation, -> {
+    where(
+      'NOT EXISTS (SELECT 1 FROM aggregation_filters f WHERE pull_requests.user_id = f.user_id AND pull_requests.repo_name LIKE f.repo_pattern)'
+    )
+  }
+
   EARLIEST_PULL_DATE = Date.parse("01/12/#{CURRENT_YEAR}").midnight
   LATEST_PULL_DATE   = Date.parse("25/12/#{CURRENT_YEAR}").midnight
 
@@ -63,6 +69,10 @@ class PullRequest < ActiveRecord::Base
 
   def gifted_state
     gifts.any? ? :gifted : :not_gifted
+  end
+
+  def update_user_pr_count
+    user.update_pr_count
   end
 
   def autogift

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -13,7 +13,7 @@ class PullRequest < ActiveRecord::Base
   scope :by_language, -> (language) { where('lower(language) = ?', language.downcase) }
   scope :latest, -> (limit) { order('created_at desc').limit(limit) }
   scope :for_aggregation, -> {
-    where(AggregationFilter::PULL_REQUEST_SQL_FILTER)
+    where(AggregationFilter::PULL_REQUEST_FILTER)
   }
 
   EARLIEST_PULL_DATE = Date.parse("01/12/#{CURRENT_YEAR}").midnight

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,11 +4,14 @@ class User < ActiveRecord::Base
 
   attr_writer :gift_factory
 
-  has_many :pull_requests, dependent: :destroy
-  has_many :skills,        dependent: :destroy
-  has_many :gifts,         dependent: :destroy
+  has_many :pull_requests,       dependent: :destroy
+  has_many :skills,              dependent: :destroy
+  has_many :gifts,               dependent: :destroy
+  has_many :aggregation_filters, dependent: :destroy
+
   has_many :projects
   has_many :events
+
   has_and_belongs_to_many :organisations
 
   has_many :archived_pull_requests

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -198,6 +198,10 @@ class User < ActiveRecord::Base
     update_column(:thank_you_email_sent, true)
   end
 
+  def update_pull_request_count
+    update_attribute(:pull_requests_count, pull_requests.for_aggregation.count)
+  end
+
   private
 
   def repo_languages

--- a/db/migrate/20151217144215_create_aggregation_filters.rb
+++ b/db/migrate/20151217144215_create_aggregation_filters.rb
@@ -1,0 +1,10 @@
+class CreateAggregationFilters < ActiveRecord::Migration
+  def change
+    create_table :aggregation_filters do |t|
+      t.belongs_to :user, index: true, foreign_key: true
+      t.string :repo_pattern
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20151223170543_rename_filter_column.rb
+++ b/db/migrate/20151223170543_rename_filter_column.rb
@@ -1,0 +1,5 @@
+class RenameFilterColumn < ActiveRecord::Migration
+  def change
+    rename_column :aggregation_filters, :repo_pattern, :title_pattern
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,16 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151217162334) do
+ActiveRecord::Schema.define(version: 20151223170543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "aggregation_filters", force: :cascade do |t|
     t.integer  "user_id"
-    t.string   "repo_pattern"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.string   "title_pattern"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
   end
 
   add_index "aggregation_filters", ["user_id"], name: "index_aggregation_filters_on_user_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,15 @@ ActiveRecord::Schema.define(version: 20151217162334) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "aggregation_filters", force: :cascade do |t|
+    t.integer  "user_id"
+    t.string   "repo_pattern"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
+
+  add_index "aggregation_filters", ["user_id"], name: "index_aggregation_filters_on_user_id", using: :btree
+
   create_table "archived_pull_requests", force: :cascade do |t|
     t.string   "title"
     t.string   "issue_url"
@@ -158,12 +167,13 @@ ActiveRecord::Schema.define(version: 20151217162334) do
     t.string   "name"
     t.string   "blog"
     t.string   "location"
+    t.boolean  "thank_you_email_sent",                         default: false
     t.decimal  "lat",                  precision: 8, scale: 6
     t.decimal  "lng",                  precision: 9, scale: 6
-    t.boolean  "thank_you_email_sent",                         default: false
   end
 
   add_index "users", ["nickname"], name: "index_users_on_nickname", unique: true, using: :btree
   add_index "users", ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true, using: :btree
 
+  add_foreign_key "aggregation_filters", "users"
 end

--- a/lib/tasks/pull_requests.rake
+++ b/lib/tasks/pull_requests.rake
@@ -14,9 +14,7 @@ end
 desc 'Refresh pull request counts'
 task refresh_pull_request_counts: :environment do
   User.reset_column_information
-  User.all.each do |u|
-    u.update_pull_request_count
-  end
+  User.all.find_each(&:update_pull_request_count)
 end
 
 desc 'Download new pull requests'

--- a/lib/tasks/pull_requests.rake
+++ b/lib/tasks/pull_requests.rake
@@ -15,7 +15,7 @@ desc 'Refresh pull request counts'
 task refresh_pull_request_counts: :environment do
   User.reset_column_information
   User.all.each do |u|
-    User.reset_counters(u.id, :pull_requests)
+    u.update_pull_request_count
   end
 end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,6 +2,11 @@ require 'securerandom'
 require 'rspec/mocks'
 
 FactoryGirl.define do
+  factory :aggregation_filter do
+    user nil
+    repo_pattern "MyString"
+  end
+
   sequence :email do |n|
     "email#{n}@factory.com"
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,7 +4,7 @@ require 'rspec/mocks'
 FactoryGirl.define do
   factory :aggregation_filter do
     user nil
-    repo_pattern "MyString"
+    title_pattern "MyString"
   end
 
   sequence :email do |n|

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -15,14 +15,6 @@ describe Organisation, type: :model do
     expect(ordered_organisations.last.pull_request_count).to eq(2)
   end
 
-  it 'with_user_counts' do
-    setup_organizations_with_users
-
-    organisations_with_user_counts = Organisation.with_user_counts
-    expect(organisations_with_user_counts.first.users_count).to eq(3)
-    expect(organisations_with_user_counts.last.users_count).to eq(1)
-  end
-
   def setup_pull_request_data
     most_pr_user = create(:user)
     3.times { create :pull_request, user: most_pr_user }
@@ -38,14 +30,4 @@ describe Organisation, type: :model do
     create :organisation, login: 'kobol',  users: [most_pr_user, some_pr_user, low_pr_user]
     create :organisation, login: 'caprica', users: [most_pr_user, some_pr_user]
   end
-
-  def setup_organizations_with_users
-    user_one = create(:user)
-    user_two = create(:user)
-    user_three = create(:user)
-
-    create :organisation, login: 'pugnation', users: [user_one, user_two, user_three]
-    create :organisation, login: 'caprica', users: [user_three]
-  end
-
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -33,17 +33,17 @@ describe Organisation, type: :model do
   context 'with pull request filtering' do
     let(:user) do
       user = create(:user)
-      create :aggregation_filter, user: user, repo_pattern: '%_filtered'
+      create :aggregation_filter, user: user, title_pattern: '% filtered'
 
       user
     end
 
     let!(:included_pr) do
-      create(:pull_request, user: user, repo_name: 'should be included')
+      create(:pull_request, user: user, title: 'should be included')
     end
 
     let!(:filtered_pr) do
-      create(:pull_request, user: user, repo_name: 'should_be_filtered')
+      create(:pull_request, user: user, title: 'should be filtered')
     end
 
     let(:organisation) do

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -50,8 +50,6 @@ describe Organisation, type: :model do
       organisation = create :organisation, login: 'filtered-org', users: [user]
       update_pull_request_counts
       organisation.reload
-
-      organisation
     end
 
     describe '.pull_requests' do

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -3,11 +3,8 @@ require 'rake'
 
 describe Organisation, type: :model do
 
-  it 'pull_request_count' do
+  it 'orders organisations by pull request count' do
     setup_pull_request_data
-
-    Tfpullrequests::Application.load_tasks
-    Rake::Task['organisations:update_pull_request_count'].invoke
 
     ordered_organisations = Organisation.order_by_pull_requests
 
@@ -25,9 +22,59 @@ describe Organisation, type: :model do
     some_pr_user = create(:user)
     2.times { create :pull_request, user: some_pr_user }
 
-    create :organisation, login: 'pugnation', users: [most_pr_user, low_pr_user]
-    create :organisation, login: '24pullrequsts', users: [some_pr_user]
-    create :organisation, login: 'kobol',  users: [most_pr_user, some_pr_user, low_pr_user]
-    create :organisation, login: 'caprica', users: [most_pr_user, some_pr_user]
+    create :organisation, login: 'most_low_org', users: [most_pr_user, low_pr_user]
+    create :organisation, login: 'some_org', users: [some_pr_user]
+    create :organisation, login: 'all_org',  users: [most_pr_user, some_pr_user, low_pr_user]
+    create :organisation, login: 'most_some_org', users: [most_pr_user, some_pr_user]
+
+    update_pull_request_counts
+  end
+
+  context 'with pull request filtering' do
+    let(:user) do
+      user = create(:user)
+      create :aggregation_filter, user: user, repo_pattern: '%_filtered'
+
+      user
+    end
+
+    let!(:included_pr) do
+      create(:pull_request, user: user, repo_name: 'should be included')
+    end
+
+    let!(:filtered_pr) do
+      create(:pull_request, user: user, repo_name: 'should_be_filtered')
+    end
+
+    let(:organisation) do
+      organisation = create :organisation, login: 'filtered-org', users: [user]
+      update_pull_request_counts
+      organisation.reload
+
+      organisation
+    end
+
+    describe '.pull_requests' do
+      subject { organisation.pull_requests }
+
+      it 'should include only non-filtered pull requests' do
+        is_expected.to include included_pr
+        is_expected.not_to include filtered_pr
+      end
+    end
+
+    describe '.pull_requests_count' do
+      subject { organisation.pull_request_count }
+
+      it 'should count only non-filtered pull requests' do
+        is_expected.to eq(PullRequest.all.count - 1)
+      end
+    end
+  end
+
+  def update_pull_request_counts
+    Tfpullrequests::Application.load_tasks
+    Rake::Task['refresh_pull_request_counts'].execute
+    Rake::Task['organisations:update_pull_request_count'].execute
   end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -46,6 +46,10 @@ describe Organisation, type: :model do
       create(:pull_request, user: user, title: 'should be filtered')
     end
 
+    let!(:uppercase_filtered_pr) do
+      create(:pull_request, user: user, title: 'SHOULD ALSO BE FILTERED')
+    end
+
     let(:organisation) do
       organisation = create :organisation, login: 'filtered-org', users: [user]
       update_pull_request_counts
@@ -59,13 +63,19 @@ describe Organisation, type: :model do
         is_expected.to include included_pr
         is_expected.not_to include filtered_pr
       end
+
+      it 'should not be case sensitive when filtering pull requests' do
+        is_expected.to include included_pr
+        is_expected.not_to include filtered_pr
+        is_expected.not_to include uppercase_filtered_pr
+      end
     end
 
     describe '.pull_requests_count' do
       subject { organisation.pull_request_count }
 
       it 'should count only non-filtered pull requests' do
-        is_expected.to eq(PullRequest.all.count - 1)
+        is_expected.to eq(PullRequest.all.count - 2)
       end
     end
   end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe PullRequest, type: :model do
   let(:user) { create :user }
+  subject { create :pull_request, user: user }
 
   it { is_expected.to belong_to(:user) }
   it { is_expected.to validate_uniqueness_of(:issue_url).scoped_to(:user_id) }

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe PullRequest, type: :model do
   let(:user) { create :user }
-  subject { create :pull_request, user: user }
 
   it { is_expected.to belong_to(:user) }
   it { is_expected.to validate_uniqueness_of(:issue_url).scoped_to(:user_id) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -272,6 +272,41 @@ describe User, type: :model do
 
       it { is_expected.to eq 1 }
     end
+
+    context 'with some pull requests filtered' do
+      before do
+        create :aggregation_filter, user: user, repo_pattern: '%_filtered'
+        create(:pull_request, user: user, repo_name: 'should be included')
+        create(:pull_request, user: user, repo_name: 'should_be_filtered')
+      end
+
+      it "should not include all the user's filtered requests in their aggregated count" do
+        is_expected.to eq(user.pull_requests.all.count - 1)
+      end
+    end
+  end
+
+  describe '.pull_requests' do
+    subject { user.pull_requests }
+
+    context 'with some pull requests filtered' do
+      before do
+        create :aggregation_filter, user: user, repo_pattern: '%_filtered'
+      end
+
+      let(:included_pr) do
+        create(:pull_request, user: user, repo_name: 'should be included')
+      end
+
+      let(:filtered_pr) do
+        create(:pull_request, user: user, repo_name: 'should_be_filtered')
+      end
+
+      it 'should always show the full pull request list' do
+        is_expected.to include included_pr
+        is_expected.to include filtered_pr
+      end
+    end
   end
 
   describe '.to_param' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -275,9 +275,9 @@ describe User, type: :model do
 
     context 'with some pull requests filtered' do
       before do
-        create :aggregation_filter, user: user, repo_pattern: '%_filtered'
-        create(:pull_request, user: user, repo_name: 'should be included')
-        create(:pull_request, user: user, repo_name: 'should_be_filtered')
+        create :aggregation_filter, user: user, title_pattern: '% filtered'
+        create(:pull_request, user: user, title: 'should be included')
+        create(:pull_request, user: user, title: 'should be filtered')
       end
 
       it "should not include all the user's filtered requests in their aggregated count" do
@@ -291,15 +291,15 @@ describe User, type: :model do
 
     context 'with some pull requests filtered' do
       before do
-        create :aggregation_filter, user: user, repo_pattern: '%_filtered'
+        create :aggregation_filter, user: user, title_pattern: '% filtered'
       end
 
       let(:included_pr) do
-        create(:pull_request, user: user, repo_name: 'should be included')
+        create(:pull_request, user: user, title: 'should be included')
       end
 
       let(:filtered_pr) do
-        create(:pull_request, user: user, repo_name: 'should_be_filtered')
+        create(:pull_request, user: user, title: 'should be filtered')
       end
 
       it 'should always show the full pull request list' do


### PR DESCRIPTION
This pull request is an attempt to deal with #1043. This is likely to end up closer to being a proposal than a final answer, but I'm hoping a concrete fix might help move conversation forward a bit.

Some notes:

* This changes how PRs appear on the org leaderboard and pages, and the user PR total on user badges.
* It doesn't change the PR total or list of PRs shown on the user page.
* This is a slightly simpler filtering design than proposed at some points, filtering only on repo pattern for a given user. We could easily extend this and tweak it to whatever else we wanted though, with tiny changes in `aggregation_filter.rb`, I'm checking the overall approach first. I think this is a reasonable & effective solution, which I'd be happy to have it merged if people agree, but I'm not too attached to it.
* This includes the removal of `Organisation.with_user_counts`, `User.users_with_pull_request_counts`, `organisation_tooltip`, and a related helper: they'd potentially need changes en route, but fortunately none of this code is actually being used anywhere any more, so I've just got rid of all of it.
* There's no indexing here for the repo name filtering. That can be done but it's non-trivial (because of the non-constant LIKE query). I think it won't matter much anyway since there'll be very very few of these filters and they're scoped by user, so the patterns won't be being checked very often, and this is only ever used in the background job anyway, so small potential delays aren't a big problem.

I've done very little Rails before, so this might not be idiomatic, sorry! Do shout if there are issues, happy to change things to fit The Rails Way.