### PR TITLE
Re-enable and fix tweet posting test

### DIFF
--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -19,19 +19,20 @@ describe PullRequest, type: :model do
     its(:repo_name)  { should eq json['repo']['name'] }
     its(:language)   { should eq json['repo']['language'] }
 
-    # context 'when the user has authed their twitter account' do
-    #   let(:user) { create :user, :twitter_token => 'foo', :twitter_secret => 'bar' }
+    context 'when the user has authed their twitter account' do
+      let(:user) { create :user, :twitter_token => 'foo', :twitter_secret => 'bar' }
 
-    #   it 'tweets the pull request' do
-    #     twitter = double('twitter')
-    #     twitter.stub(:update)
-    #     User.any_instance.stub(:twitter).and_return(twitter)
+      it 'can tweet the pull request' do
+        twitter = double('twitter')
+        twitter.stub(:update)
+        User.any_instance.stub(:twitter).and_return(twitter)
 
-    #     user.twitter.should_receive(:update)
-    #       .with(I18n.t 'pull_request.twitter_message', :issue_url => json['payload']['pull_request']['_links']['html']['href'])
-    #     user.pull_requests.create_from_github(json)
-    #   end
-    # end
+        user.twitter.should_receive(:update)
+          .with(I18n.t 'pull_request.twitter_message', :issue_url => json['payload']['pull_request']['_links']['html']['href'])
+
+        user.pull_requests.create_from_github(json).post_tweet
+      end
+    end
   end
 
   describe '#autogift' do


### PR DESCRIPTION
This test was temporarily commented out, more than a year ago. With this patch it's now replaced with two new up to date working ones covering the current state of the tweeting functionality, moving to the new RSpec syntax, and refactoring a little for clarity.