### PR TITLE
Make the pull request helper tests pass

### DIFF
--- a/spec/helpers/pull_request_helper_spec.rb
+++ b/spec/helpers/pull_request_helper_spec.rb
@@ -4,14 +4,15 @@ describe PullRequestHelper, type: :helper do
   before do
     1.times { create :pull_request, language: 'HTML' }
     2.times { create :pull_request, language: 'Ruby' }
+    4.times { create :pull_request, created_at: DateTime.now - 1.year }
   end
 
   describe '#pull_request_count' do
-    it 'returns the number of all pull_request' do
-      expect(helper.pull_request_count).to eql(1)
+    it 'returns the number of pull requests in the current year' do
+      expect(helper.pull_request_count).to eql(3)
     end
 
-    it 'returns the number of all users using a language' do
+    it 'returns the number of all pull requests in a given language' do
       @language = 'ruby'
 
       expect(helper.pull_request_count).to eql(2)


### PR DESCRIPTION
Currently the pull request helper tests don't pass, but nobody notices because the filename doesn't end in _spec, so they're not actually run.

This patch fixes the test (should count 3 PRs, not just 1), renames it so it runs, and makes sure it covers the 'only this year' case.