### PR TITLE
Allow web console from vagrant host

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,4 +35,7 @@ Tfpullrequests::Application.configure do
     address: 'localhost',
     port:    1025
   }
+
+  # Allow Vagrant host access to web console
+  config.web_console.whitelisted_ips = '192.168.12.1'
 end


### PR DESCRIPTION
Currently when running through Vagrant every request logs `Cannot render console from 192.168.12.1! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255` to the console. This is a bit annoying, and also obviously means if you can't enable the web console anywhere to play around with things from the host.

This PR adds the Vagrant host IP to the allowed list for console rendering (removing that error), in development mode only.