### PR TITLE
Improve test setup step docs, and make Ansible run them automatically

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,8 @@ Now you can go to your regular browser, in the Host machine (your main OS) and a
 
 Any changes that you make to the app files will be reflected inside the VM server. You can use your regular workflow for development, as if the server was local.
 
+You can run the tests with `bundle exec rake spec` (or spec:models, etc) from inside the VM too. As outside, you may need to run `bundle exec rake db:test:prepare` occasionally to bring the DB up to date with recent changes.
+
 When you want to pause or finish working, you can run:
 
     $ vagrant suspend

--- a/Readme.md
+++ b/Readme.md
@@ -120,7 +120,7 @@ Simply edit the files in the project directory using your favorite editor on you
 
 Standard RSpec/Capybara tests are used for testing the application. The tests can be run with `bundle exec rake`.
 
-You can set up the test environment with `rake db:test:prepare`, which will create the test DB and populate its schema automatically. You don't need to do this for every test run, but it will let you easily keep up with migrations. If you find a large number of tests are failing you should probably run this.
+You can set up the test environment with `bundle exec rake db:test:prepare`, which will create the test DB and populate its schema automatically. You don't need to do this for every test run, but it will let you easily keep up with migrations. If you find a large number of tests are failing you should probably run this.
 
 Mocha/Konacha is used for unit testing any JavaScript. JavaScript specs
 should be placed in `spec/javascripts`. Run the JavaScript specs with

--- a/Readme.md
+++ b/Readme.md
@@ -118,10 +118,9 @@ Simply edit the files in the project directory using your favorite editor on you
 
 ### Tests
 
-Standard RSpec/Capybara tests are used for testing the application. The
-tests can be run with `bundle exec rake`.
+Standard RSpec/Capybara tests are used for testing the application. The tests can be run with `bundle exec rake`.
 
-(If you find a large number of tests failing right after you've cloned the project and run migrations, try running `rake db:schema:load`. This will reload the database schema and fix any issues relating to missing tables.)
+You can set up the test environment with `rake db:test:prepare`, which will create the test DB and populate its schema automatically. You don't need to do this for every test run, but it will let you easily keep up with migrations. If you find a large number of tests are failing you should probably run this.
 
 Mocha/Konacha is used for unit testing any JavaScript. JavaScript specs
 should be placed in `spec/javascripts`. Run the JavaScript specs with

--- a/ansible/roles/app/tasks/main.yml
+++ b/ansible/roles/app/tasks/main.yml
@@ -31,3 +31,7 @@
 - name: Feed DB
   sudo: false
   shell: bundle exec rake db:seed chdir=/vagrant
+
+- name: Rake db:test:prepare
+  sudo: false
+  shell: bundle exec rake db:test:prepare chdir=/vagrant

--- a/ansible/roles/pgsql/tasks/main.yml
+++ b/ansible/roles/pgsql/tasks/main.yml
@@ -24,12 +24,14 @@
 - name: Create databases
   sudo: yes
   sudo_user: postgres
-  postgresql_db: name={{ database.db }} state=present
+  postgresql_db: name={{ item.db }} state=present
+  with_items: databases
 
 - name: Create users
   sudo: yes
   sudo_user: postgres
-  postgresql_user: name={{ database.user }} password={{ database.pass }} db={{ database.db }} priv=ALL
+  postgresql_user: name={{ item.user }} password={{ item.pass }} db={{ item.db }} priv=ALL
+  with_items: databases
 
 - name: Change default pg_hba.conf to allow local connections without pass
   sudo: yes

--- a/ansible/roles/pgsql/tasks/main.yml
+++ b/ansible/roles/pgsql/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: Create users
   sudo: yes
   sudo_user: postgres
-  postgresql_user: name={{ database.user }} password={{ database.pass }} db={{ database.db }} priv=ALL
+  postgresql_user: name={{ database.user }} password={{ database.pass }} db={{ database.db }} priv=ALL role_attr_flags=SUPERUSER
 
 - name: Change default pg_hba.conf to allow local connections without pass
   sudo: yes

--- a/ansible/roles/pgsql/tasks/main.yml
+++ b/ansible/roles/pgsql/tasks/main.yml
@@ -24,14 +24,12 @@
 - name: Create databases
   sudo: yes
   sudo_user: postgres
-  postgresql_db: name={{ item.db }} state=present
-  with_items: databases
+  postgresql_db: name={{ database.db }} state=present
 
 - name: Create users
   sudo: yes
   sudo_user: postgres
-  postgresql_user: name={{ item.user }} password={{ item.pass }} db={{ item.db }} priv=ALL
-  with_items: databases
+  postgresql_user: name={{ database.user }} password={{ database.pass }} db={{ database.db }} priv=ALL
 
 - name: Change default pg_hba.conf to allow local connections without pass
   sudo: yes

--- a/ansible/vars/pgsql.yml
+++ b/ansible/vars/pgsql.yml
@@ -1,7 +1,4 @@
-databases:
-  - db: tfpullrequests_development
-    user: vagrant
-    pass:
-  - db: tfpullrequests_test
+database:
+    db: tfpullrequests_development
     user: vagrant
     pass:

--- a/ansible/vars/pgsql.yml
+++ b/ansible/vars/pgsql.yml
@@ -1,4 +1,7 @@
-database:
-    db: tfpullrequests_development
+databases:
+  - db: tfpullrequests_development
     user: vagrant
-    pass: 
+    pass:
+  - db: tfpullrequests_test
+    user: vagrant
+    pass:


### PR DESCRIPTION
This updates the docs to make it clearer how to do DB setup to run the tests, and updates the ansible setup to ensure this gets done immediately so you can successfully run tests in new Vagrant instances (which requires adding SUPERUSER to the Vagrant postgres user, so they can drop/recreate the test DB)