### PR TITLE
Don't unnecessarily cache org pull request count on single org page

### DIFF
--- a/app/views/organisations/show.html.haml
+++ b/app/views/organisations/show.html.haml
@@ -17,5 +17,5 @@
         = render @organisation.users.order('pull_requests_count desc')
 
 #pull_requests
-  %h3= t("organisations.pull_requests", count: @organisation.pull_request_count)
+  %h3= t("organisations.pull_requests", count: @organisation.pull_requests.length)
   = render @organisation.pull_requests


### PR DESCRIPTION
Currently the org pull request count is cached on the individual organisation page. That means it's often out of date.

We can get the exact numbers for this for free though, since we load all the pull requests into memory on the next line anyway. With this PR they're all loaded into memory slightly earlier, so we can count them exactly. This results in no extra queries, but ensures the PR count is always exactly correct on this page.