### PR TITLE
Locked down shoulda-matchers + Upgraded 2 others gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ group :development, :test, :cucumber do
   gem 'launchy'
 
   gem 'database_cleaner'
-  gem 'shoulda-matchers'
+  gem 'shoulda-matchers', '3.0.1' # LOCKED DOWN: Watch https://github.com/thoughtbot/shoulda-matchers/issues/880
   gem 'webmock', require: false
   gem 'timecop'
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     addressable (2.3.8)
     arel (6.0.3)
     ast (2.2.0)
-    autoprefixer-rails (6.3.0)
+    autoprefixer-rails (6.3.1)
       execjs
       json
     bootstrap-sass (3.3.6)
@@ -241,7 +241,7 @@ GEM
     omniauth-twitter (1.2.1)
       json (~> 1.3)
       omniauth-oauth (~> 1.1)
-    parser (2.3.0.0)
+    parser (2.3.0.1)
       ast (~> 2.2)
     pg (0.18.4)
     poltergeist (1.8.1)
@@ -364,7 +364,7 @@ GEM
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
     sexp_processor (4.6.0)
-    shoulda-matchers (3.1.0)
+    shoulda-matchers (3.0.1)
       activesupport (>= 4.0.0)
     simple_form (3.2.1)
       actionpack (> 4, < 5.1)
@@ -494,7 +494,7 @@ DEPENDENCIES
   rubocop
   sass-rails
   sassc-rails
-  shoulda-matchers
+  shoulda-matchers (= 3.0.1)
   simple_form
   simplecov
   sinon-chai-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
       tilt
     launchy (2.4.3)
       addressable (~> 2.3)
-    lodash-rails (3.10.1)
+    lodash-rails (4.0.0)
       railties (>= 3.1)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)

--- a/spec/models/project_label_spec.rb
+++ b/spec/models/project_label_spec.rb
@@ -9,7 +9,6 @@ describe ProjectLabel, type: :model do
     end
 
     it 'must only have a label allocated to a project once' do
-      skip
       is_expected.to validate_uniqueness_of(:label_id).scoped_to(:project_id)
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -5,7 +5,7 @@ describe Project, type: :model do
   it { is_expected.to validate_presence_of(:github_url) }
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_presence_of(:main_language) }
-  skip { is_expected.to validate_uniqueness_of(:github_url).
+  it { is_expected.to validate_uniqueness_of(:github_url).
     case_insensitive.with_message('Project has already been suggested.') }
   it { is_expected.to validate_length_of(:description).is_at_least(20).is_at_most(200) }
 


### PR DESCRIPTION
* Locked down shoulda-matchers gem to 3.0.1 plus removed 2 extra "skip"s added previously to run 3.1.0 version of gem.
* Upgraded 2 others gems- autoprefixer-rails, parser.