### PR TITLE
Added fix for #1237

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,10 @@ require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = 10
 
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, window_size: [1280, 600])
+end
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }


### PR DESCRIPTION
Added fix for #1237 based on this blog article: http://stackoverflow.com/questions/6725048/unable-to-trigger-mouse-event-in-capybara-test
