### PR TITLE
explicitly require vendored javascript files in application.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,7 @@
 //= require jquery.timeago
 //= require jquery.datetimepicker
 //= require emojione
+//= require emoji
 //= require lodash
 //= require gmaps/google
 //= require_tree .

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,6 +20,7 @@
 //= require jquery.datetimepicker
 //= require emojione
 //= require emoji
+//= require jquery.icheck
 //= require lodash
 //= require gmaps/google
 //= require_tree .


### PR DESCRIPTION
Fixes broken js in a number of pages since I moved third party js into `/vendor/assets`