### PR TITLE
Add rate-limiting with Rack-Attack fixes #1587

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'typhoeus'
 gem 'sassc-rails'
 gem 'puma'
 gem 'multi_fetch_fragments'
+gem 'rack-attack'
 
 group :development do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,6 +226,8 @@ GEM
     rabl (0.13.1)
       activesupport (>= 2.3.14)
     rack (1.6.5)
+    rack-attack (5.0.1)
+      rack
     rack-canonical-host (0.2.2)
       addressable (> 0, < 3)
       rack (>= 1.0.0, < 3)
@@ -432,6 +434,7 @@ DEPENDENCIES
   puma
   quiet_assets
   rabl
+  rack-attack
   rack-canonical-host
   rack-google-analytics
   rails (= 4.2.7.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -61,6 +61,9 @@ module Tfpullrequests
 
     config.assets.initialize_on_precompile = false
 
+    # Rate limiting, see config/initializers/rack_attack.rb for config
+    config.middleware.use Rack::Attack
+
     config.exceptions_app = routes
 
     I18n.config.enforce_available_locales = false

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,9 @@
+if ENV.key?('MAX_REQUESTS_PER_MINUTE')
+  class Rack::Attack
+    whitelist('allow asset requests') do |request|
+      request.path.starts_with?('/assets')
+    end
+
+    throttle('req/ip', limit: Integer(ENV['MAX_REQUESTS_PER_MINUTE']), period: 1.minute, &:ip)
+  end
+end


### PR DESCRIPTION
Hey :)

We had this same issue @ Product Hunt. RackAttack worked great for us. We use Redis, but looks like memcached works just as well. I tested it out locally and it worked as expected.

Using an env variable because in my experience, best to be easily configurable, rather than relying on a deploy.

Also white listed `/assets`. Those should not count towards an IP addresses request limit (Found this useful in our Product Hunt config).