### PR TITLE
Use #blank? to check for Github key in estimate_skills

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,7 +92,7 @@ class User < ActiveRecord::Base
   end
 
   def estimate_skills
-    return if ENV['GITHUB_KEY'].empty?
+    return if ENV['GITHUB_KEY'].blank?
     (Project::LANGUAGES & repo_languages).each do |language|
       skills.create(language: language)
     end

--- a/app/views/users/_calendar.html.erb
+++ b/app/views/users/_calendar.html.erb
@@ -1,5 +1,3 @@
-{:class =>  }
-
 <ol class="unstyled clearfix calendar-inner">
   <% 1.upto(calendar.start_padding) do %>
     <li class="calendar-day calendar-padding"></li>


### PR DESCRIPTION
In this PR, I've switched the check on `ENV['GITHUB_KEY']` from `.empty?` to Rails' `.blank?` method, which returns `true` on both empty string and `nil`. Fixes #1592. Seeding the DB now works without setting a GitHub key.

While testing, I also came across a rogue object that looks like it might have been copied by accident from a `puts` or something, so I've deleted that.