### PR TITLE
Scope user and org pull requests to the current year everywhere

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -32,6 +32,6 @@ class Organisation < ActiveRecord::Base
   end
 
   def update_pull_request_count
-    update_attribute(:pull_request_count, pull_requests.count)
+    update_attribute(:pull_request_count, pull_requests.year(CURRENT_YEAR).count)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -200,7 +200,7 @@ class User < ActiveRecord::Base
   end
 
   def update_pull_request_count
-    update_attribute(:pull_requests_count, pull_requests.for_aggregation.count)
+    update_attribute(:pull_requests_count, pull_requests.year(CURRENT_YEAR).for_aggregation.count)
   end
 
   def lat_lng

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -23,7 +23,7 @@
 </div>
 <div id="pull_requests">
   <h3>
-    <%= t("organisations.pull_requests", count: @organisation.pull_requests.length) %>
+    <%= t("organisations.pull_requests", count: @organisation.pull_requests.year(current_year).length) %>
   </h3>
-  <%= render @organisation.pull_requests, cache: true %>
+  <%= render @organisation.pull_requests.year(current_year), cache: true %>
 </div>


### PR DESCRIPTION
There were a couple of unscoped pull request queries on user and org that meant old prs where showing up on the site, this fixes them and the counter caches too.