### PR TITLE
Faster loading of suggested_projects

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -4,7 +4,7 @@ class DashboardsController < ApplicationController
 
   def show
     pull_requests = current_user.pull_requests.year(current_year).order('created_at desc')
-    projects      = current_user.suggested_projects.limit(100).sample(12).sort_by(&:name)
+    projects      = current_user.suggested_projects.order("RANDOM()").limit(12).sort_by(&:name)
     gifted_today  = current_user.gift_for(today)
     @events = Event.where(['start_time >= ?', Time.zone.today]).order('start_time').first(5)
 

--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -26,7 +26,7 @@ class ReminderMailer < ActionMailer::Base
   private
 
   def mail_suggested_projects(user, frequency)
-    @suggested_projects = user.suggested_projects.sample(8).sort_by(&:name)
+    @suggested_projects = user.suggested_projects.order("RANDOM()").limit(8).sort_by(&:name)
     mail :to         => user.email,
          :subject    => %([24 Pull Requests] #{frequency} Reminder),
          'X-SMTPAPI' => %({"category": "#{frequency} Reminder"})

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -1,7 +1,9 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe ReminderMailer, type: :mailer do
   let(:user) do
+    allow(Project).to receive_message_chain(:order, :limit).and_return(Project.where(nil))
+
     mock_model(User,
     {
       nickname: 'David',
@@ -9,7 +11,7 @@ describe ReminderMailer, type: :mailer do
       languages: ['Ruby'],
       skills: [],
       pull_requests: double(:pull_request, year: []),
-      suggested_projects: [],
+      suggested_projects: Project.all,
     })
   end
 


### PR DESCRIPTION
Use order by random rather than loading lots of records and sampling in ruby, much more efficient to do it in the database.