### PR TITLE
Update contribulator domain

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -84,6 +84,6 @@ class Project < ActiveRecord::Base
   end
 
   def contribulator_url
-    "https://contribulator.herokuapp.com/#{github_repository}"
+    "https://contribulator.24pullrequests.com/#{github_repository}"
   end
 end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -70,7 +70,7 @@ namespace :projects do
     next unless PullRequest.in_date_range?
 
     api = JsonApi::PaginatedCollection.new(
-      domain: 'https://contribulator.herokuapp.com',
+      domain: 'https://contribulator.24pullrequests.com',
       path:   '/api/projects'
     )
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -113,6 +113,6 @@ describe Project, type: :model do
 
   it 'contribulator url' do
     project = FactoryGirl.create(:project, github_url: 'https://github.com/24pullrequests/24pullrequests')
-    expect(project.contribulator_url).to eq('https://contribulator.herokuapp.com/24pullrequests/24pullrequests')
+    expect(project.contribulator_url).to eq('https://contribulator.24pullrequests.com/24pullrequests/24pullrequests')
   end
 end


### PR DESCRIPTION
I've transferred the contribulator over to the 24pullrequests github org: https://github.com/24pullrequests/contribulator and setup a new domain for it at https://contribulator.24pullrequests.com/

This pr updates the urls to point to the new locations.

🎁