### PR TITLE
Remove activemodel-serializers-xml from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ gem 'sassc-rails'
 gem 'puma'
 gem 'multi_fetch_fragments'
 gem 'rack-attack'
-gem 'activemodel-serializers-xml' # ensures draper will run
 
 group :development do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,7 +393,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activemodel-serializers-xml
   bootstrap-sass
   brakeman
   bugsnag


### PR DESCRIPTION
It is a draper's dependency.
https://github.com/drapergem/draper/blob/v3.0.0.pre1/draper.gemspec#L24

So there is no reason that we should specify it in our Gemfile.