### PR TITLE
Suppress deprecation warning in controller specs

### DIFF
--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -7,7 +7,7 @@ describe ProjectsController, type: :controller do
     context 'as json' do
       before do
         create :project
-        get :index, format: :json
+        get :index, params: {format: :json}
       end
 
       it { expect(response.header['Content-Type']).to include 'application/json' }
@@ -161,7 +161,7 @@ describe ProjectsController, type: :controller do
             status: 200
           })
 
-        get :autofill, repo: '24pullrequests/24pullrequests/'
+        get :autofill, params: {repo: '24pullrequests/24pullrequests/'}
 
         expect(response.status).to eq(200)
 


### PR DESCRIPTION
Such as the following:
```
get :show, params: { id: 1 }, session: { user_id: 1 }
process :update, method: :post, params: { id: 1 }
 (called from block (4 levels) in <top (required)> at
 /Users/tricknotes/src/github.com/24pullrequests/24pullrequests/spec/controllers/projects_controller_spec.rb:164)
```