### PR TITLE
Make sql do the work to find 24 random users with pull requests

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -2,8 +2,8 @@ class StaticController < ApplicationController
   def homepage
     @projects = Project.includes(:labels).active.order("RANDOM()").limit(6)
     @featured_projects = Project.includes(:labels).featured.order("RANDOM()").limit(6)
-    @users = User.order('pull_requests_count desc').limit(200).sample(24)
-    @orgs = Organisation.order_by_pull_requests.limit(200).sample(24)
+    @users = User.with_any_pull_requests.random.limit(24)
+    @orgs = Organisation.with_any_pull_requests.random.limit(24)
     @pull_requests = PullRequest.year(current_year).order('created_at desc').limit(5)
   end
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -2,6 +2,8 @@ class Organisation < ApplicationRecord
   has_and_belongs_to_many :users
   has_many :pull_requests, -> { order('created_at desc').for_aggregation }, through: :users
 
+  scope :with_any_pull_requests, -> { where('organisations.pull_request_count > 0') }
+  scope :random, -> { order("RANDOM()") }
   scope :order_by_pull_requests, -> do
     order('organisations.pull_request_count desc, organisations.login asc')
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,8 @@ class User < ApplicationRecord
   has_many :archived_pull_requests
 
   scope :by_language, ->(language) { joins(:skills).where('lower(language) = ?', language.downcase) }
+  scope :with_any_pull_requests, -> { where('users.pull_requests_count > 0') }
+  scope :random, -> { order("RANDOM()") }
 
   paginates_per 99
 


### PR DESCRIPTION
We're currently loading 200 user records and 200 org records into memory on every homepage request, this just randomly picks from any users who have sent at least 1 pr in SQL 🚅