### PR TITLE
Allow users to ignore named organisations

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -79,7 +79,7 @@ class DashboardsController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:uid, :provider, :nickname, :email, :gravatar_id, :token, :email_frequency, :twitter_token, skills_attributes: [:language])
+    params.require(:user).permit(:uid, :provider, :nickname, :email, :gravatar_id, :token, :email_frequency, :twitter_token, :ignored_organisations_string, skills_attributes: [:language])
   end
 
   def set_locale_to_cookie(locale)

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -3,7 +3,12 @@ class DashboardsController < ApplicationController
   before_action :set_email_preferences, except: [:preferences, :update_preferences, :confirm_email, :locale]
 
   def show
-    pull_requests = current_user.pull_requests.year(current_year).order('created_at desc')
+    pull_requests = current_user
+      .pull_requests_ignoring_organisations
+      .year(current_year)
+      .order('created_at desc')
+      .to_a
+
     projects      = current_user.suggested_projects.order("RANDOM()").limit(12).sort_by(&:name)
     gifted_today  = current_user.gift_for(today)
     @events = Event.where(['start_time >= ?', Time.zone.today]).order('start_time').first(5)

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -16,6 +16,7 @@ class PullRequest < ApplicationRecord
     where(AggregationFilter.pull_request_filter)
   }
   scope :excluding_organisations, -> (excluded_organisations) {
+    excluded_organisations = Array(excluded_organisations)
     where.not("repo_name ~* ?", %{^(#{excluded_organisations.join("|")})/})
   }
 

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -15,6 +15,9 @@ class PullRequest < ApplicationRecord
   scope :for_aggregation, -> {
     where(AggregationFilter.pull_request_filter)
   }
+  scope :excluding_organisations, -> (excluded_organisations) {
+    where.not("repo_name ~* ?", %{^(#{excluded_organisations.join("|")})/})
+  }
 
   EARLIEST_PULL_DATE = Date.parse("01/12/#{CURRENT_YEAR}").midnight
   LATEST_PULL_DATE   = Date.parse("25/12/#{CURRENT_YEAR}").midnight

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -209,6 +209,17 @@ class User < ApplicationRecord
     lat && lng
   end
 
+  def ignored_organisations_string
+    (ignored_organisations || []).join(", ")
+  end
+
+  def ignored_organisations_string= organisations_string
+    self.ignored_organisations = (organisations_string || "")
+      .split(",")
+      .collect(&:strip)
+      .compact
+  end
+
   private
 
   def repo_languages

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -184,7 +184,7 @@ class User < ApplicationRecord
 
   def unspent_pull_requests
     gifted_pull_requests = gifts.map(&:pull_request)
-    pull_requests.year(CURRENT_YEAR).reject { |pr| gifted_pull_requests.include?(pr) }
+    pull_requests_ignoring_organisations.year(CURRENT_YEAR).reject { |pr| gifted_pull_requests.include?(pr) }
   end
 
   def needs_setup?
@@ -218,6 +218,10 @@ class User < ApplicationRecord
       .split(",")
       .collect(&:strip)
       .compact
+  end
+
+  def pull_requests_ignoring_organisations
+    pull_requests.excluding_organisations(ignored_organisations)
   end
 
   private

--- a/app/views/dashboards/preferences.html.erb
+++ b/app/views/dashboards/preferences.html.erb
@@ -32,6 +32,10 @@
       <% else %>
         <%= form.input :email, :label => t("preferences.form.email") %>
       <% end %>
+      <p>
+        <%= t("preferences.ignore_organisations") %>
+      </p>
+      <%= form.input :ignored_organisations_string, label: t("preferences.ignored_organisations"), input_html: {class: "pull-left"} %>
     </div>
     <div class="col-md-12">
       <h2 class="text-center">

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -20,9 +20,9 @@
       <% if pull_requests.any? %>
         <h3>
           <%= t("your_pull_requests") %>
-          <% if current_user.pull_requests.year(current_year).any? %>
+          <% if pull_requests.any? %>
             <span class="label label-info" id="pull-requests-count">
-              <%= current_user.pull_requests.year(current_year).count %>
+              <%= pull_requests.count %>
             </span>
           <% end %>
         </h3>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -63,13 +63,13 @@
     <% end %>
     <div class="profile-pull-request-count">
       <%= octicon "gift" %>
-      <%= t("user.pull_request_count", user: @user.nickname, count: @user.pull_requests.year(current_year).count, year: current_year) %>
+      <%= t("user.pull_request_count", user: @user.nickname, count: @user.pull_requests_ignoring_organisations.year(current_year).count, year: current_year) %>
     </div>
   </div>
 </div>
 <div class="row">
   <div class="col-sm-12">
-    <% if @user.gifts.year(current_year).any? or @user.pull_requests.year(current_year).any? %>
+    <% if @user.gifts.year(current_year).any? or @user.pull_requests_ignoring_organisations.year(current_year).any? %>
       <ul class="nav nav-tabs" id="presents">
         <li>
           <a class="active" data-toggle="tab" href="#gifts">Gifts</a>
@@ -90,7 +90,7 @@
           <%= render :partial => 'calendar', :object => @calendar %>
         </div>
         <div class="tab-pane" id="pull_requests">
-          <%= render partial: 'users/pull_request', collection: @user.pull_requests.year(current_year).latest(nil), cache: true %>
+          <%= render partial: 'users/pull_request', collection: @user.pull_requests_ignoring_organisations.year(current_year).latest(nil), cache: true %>
         </div>
         <% for year in ArchivedPullRequest::PAST_YEARS %>
           <div class="tab-pane" id="<%= year %>">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -306,6 +306,11 @@ en:
       form.
     title: Set your personal preferences
     twitter: Twitter Account
+    ignore_organisations: >
+      If you regularly contribute to public repositories that you don't want to track
+      on this site, add the organisation name here. You can add multiple organisations
+      separated by commas. This can be useful if you code in the open at work, or
+      maintain an open source repository yourself. Example: "24pullrequests, alphagov"
   preferred_languages: Preferred Languages
   projects:
     admin:

--- a/db/migrate/20161202190959_add_ignored_organisations.rb
+++ b/db/migrate/20161202190959_add_ignored_organisations.rb
@@ -1,0 +1,7 @@
+class AddIgnoredOrganisations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :ignored_organisations, :string, array: true, default: nil
+    User.update_all(ignored_organisations: "{}")
+    change_column_default(:users, :ignored_organisations, [])
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161127203934) do
+ActiveRecord::Schema.define(version: 20161202190959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -140,16 +140,16 @@ ActiveRecord::Schema.define(version: 20161127203934) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "uid",                                                          null: false
-    t.string   "provider",                                                     null: false
-    t.string   "nickname",                                                     null: false
+    t.string   "uid",                                                           null: false
+    t.string   "provider",                                                      null: false
+    t.string   "nickname",                                                      null: false
     t.string   "email"
-    t.datetime "created_at",                                                   null: false
-    t.datetime "updated_at",                                                   null: false
+    t.datetime "created_at",                                                    null: false
+    t.datetime "updated_at",                                                    null: false
     t.string   "gravatar_id"
     t.string   "token"
     t.string   "email_frequency"
-    t.integer  "pull_requests_count",                          default: 0
+    t.integer  "pull_requests_count",                           default: 0
     t.datetime "last_sent_at"
     t.string   "twitter_token"
     t.string   "twitter_secret"
@@ -160,9 +160,10 @@ ActiveRecord::Schema.define(version: 20161127203934) do
     t.string   "name"
     t.string   "blog"
     t.string   "location"
-    t.decimal  "lat",                  precision: 8, scale: 6
-    t.decimal  "lng",                  precision: 9, scale: 6
-    t.boolean  "thank_you_email_sent",                         default: false
+    t.boolean  "thank_you_email_sent",                          default: false
+    t.decimal  "lat",                   precision: 8, scale: 6
+    t.decimal  "lng",                   precision: 9, scale: 6
+    t.string   "ignored_organisations",                         default: [],                 array: true
     t.index ["nickname"], name: "index_users_on_nickname", unique: true, using: :btree
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true, using: :btree
   end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -81,28 +81,31 @@ describe PullRequest, type: :model do
   end
 
   context '#scopes' do
-    let(:user) do
-      create :user, nickname: 'foo'
-    end
+    describe '.by_language' do
+      let!(:pull_requests) { create_list(:pull_request, 4, language: 'Haskell') }
 
-    let!(:pull_requests) do
-      4.times.map  do |n|
-        create(:pull_request, language:   'Haskell',
-                              created_at: DateTime.now + n.minutes,
-                              user: user)
+      it 'returns only pull requests for the requested language' do
+        expect(PullRequest.by_language('Haskell').to_set).to eq pull_requests.to_set
       end
     end
 
-    it 'by_language' do
-      expect(PullRequest.by_language('Haskell').order('created_at asc')).to eq pull_requests
+    describe '.latest' do
+      let!(:pull_requests) do
+        4.times.map do |n|
+          create(:pull_request, created_at: DateTime.now + n.minutes)
+        end
+      end
+
+      it 'returns the requested number of pull requests in order' do
+        expect(PullRequest.latest(3)).to eq(pull_requests.reverse.take(3))
+      end
     end
 
-    it 'latest' do
-      expect(PullRequest.latest(3)).to eq(pull_requests.reverse.take(3))
-    end
-
-    describe '#active_users' do
+    describe '.active_users' do
       it 'finds users' do
+        user = create :user, nickname: 'foo'
+        create(:pull_request, user: user)
+
         expect(PullRequest.active_users(CURRENT_YEAR).map(&:nickname)).to eq(%w(foo))
       end
 

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -116,5 +116,16 @@ describe PullRequest, type: :model do
         expect(PullRequest.active_users(CURRENT_YEAR)).to eq([])
       end
     end
+
+    describe '.excluding_organisations' do
+      let!(:foo) { create :pull_request, repo_name: "fooinc/foo" }
+      let!(:bar) { create :pull_request, repo_name: "barinc/bar" }
+      let!(:baz) { create :pull_request, repo_name: "bazinc/baz" }
+      let!(:qux) { create :pull_request, repo_name: "quxinc/qux" }
+
+      it 'excludes ignored organisations' do
+        expect(PullRequest.excluding_organisations(%w{fooinc quxinc})).to eq [bar, baz]
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -343,6 +343,22 @@ describe User, type: :model do
     end
   end
 
+  describe '#ignored_organisations_string' do
+    before { user.ignored_organisations = %w{foo bar} }
+
+    it "converts the organisations to a string" do
+      expect(user.ignored_organisations_string).to eq("foo, bar")
+    end
+  end
+
+  describe '#ignored_organisations_string=' do
+    before { user.ignored_organisations_string = "foo,bar, moo,     oink," }
+
+    it "converts the string of organisations to set of tags" do
+      expect(user.ignored_organisations.to_set).to eq(%w{foo bar moo oink}.to_set)
+    end
+  end
+
   context '#scopes' do
     let!(:haskell_users) { 2.times.map { create(:skill, language: 'Haskell').user } }
 
@@ -351,5 +367,4 @@ describe User, type: :model do
       expect(User.by_language('ruby')).to eq([])
     end
   end
-
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -45,7 +45,7 @@ describe 'Dashboard', type: :request do
     end
   end
 
-  describe 'email preferences' do
+  describe 'language preferences' do
     before do
       visit preferences_path
     end
@@ -54,6 +54,23 @@ describe 'Dashboard', type: :request do
       check 'Ruby'
       click_on 'Save and Continue'
       expect(user.languages).to eq ['Ruby']
+    end
+  end
+
+  describe 'ignored organisations' do
+    before do
+      user.ignored_organisations = %w{baz qux}
+      user.save!
+      visit preferences_path
+    end
+
+    it { is_expected.to have_field 'Ignored Organisations', with: 'baz, qux' }
+
+    it 'allows the user to set their preferences' do
+      fill_in 'Ignored Organisations', with: 'foo, bar'
+      click_on 'Save and Continue'
+      user.reload
+      expect(user.ignored_organisations.sort).to eq %w{bar foo}
     end
   end
 end


### PR DESCRIPTION
For users who code in the open in their day job, it's too easy to "cheat" at 24 pull requests. It makes it difficult for them to track real open source contributions versus PRs they normally make every day.

This PR adds a field to the user's preferences to allow them to specify organisations to ignore. PRs for repos under these organisations don't count towards the user's stats and aren't automatically added to the calendar.

Screenshot:

<img width="555" alt="screen shot 2016-12-02 at 23 07 26" src="https://cloud.githubusercontent.com/assets/18276/20853494/24320056-b8e4-11e6-965c-a02eb2393deb.png">
