### PR TITLE
Fixed coderwall url to avoid mixed-content warning

### DIFF
--- a/vendor/assets/javascripts/coderwall.js
+++ b/vendor/assets/javascripts/coderwall.js
@@ -34,7 +34,7 @@
       self = this;
       self.teamFetcher = function(coder, count) {
         return $.jsonp({
-          url: 'http://coderwall.com/' + coder + '.json?callback=?',
+          url: 'https://coderwall.com/' + coder + '.json?callback=?',
           cache: true,
           success: function(coder, resp) {
             return self.storeTeamBadges(coder, resp);
@@ -93,7 +93,7 @@
       }
       teamBadgesList += '</ul>';
       compileCoderList = function(coder) {
-        return '<a href="http://coderwall.com/' + coder + '" target="_blank">' + coder + '</a>';
+        return '<a href="https://coderwall.com/' + coder + '" target="_blank">' + coder + '</a>';
       };
       // teamBadgesList += '<div class="team-coders"><strong>' + I18n.user.coderwall.achieved_by + ':&nbsp;</strong>';
       teamBadgesList += '<div class="team-coders"><strong> Badges achieved by:&nbsp;</strong>';


### PR DESCRIPTION
Coderwall ajax call is done over http which causes a mixed-warning and the call will not be executed

![image](https://cloud.githubusercontent.com/assets/1374857/20867080/8873cc08-ba3c-11e6-9df6-14c7de6cf228.png)
