### PR TITLE
Improved wording in confirmation email

### DIFF
--- a/app/views/confirmation_mailer/confirmation.html.erb
+++ b/app/views/confirmation_mailer/confirmation.html.erb
@@ -1,6 +1,6 @@
 <p>Hi <%= @user.nickname %>,</p>
 <p>
-  You entered this email address as your contact address for 24pullrequests.com. Please confirm this by clicking the link below:
+  You entered this email address as your contact address for 24pullrequests.com. Please confirm this by clicking the following link:
   <% confirm_link = "http://24pullrequests.com/confirm/#{@user.confirmation_token}" %>
   <a>
     <%= link_to confirm_link, confirm_link %>


### PR DESCRIPTION
In the HTML, the link is not actually below the sentence describing it, so that 'the link below' can be confusing.