### PR TITLE
Add placeholder text to ignored organisations form

### DIFF
--- a/app/views/dashboards/preferences.html.erb
+++ b/app/views/dashboards/preferences.html.erb
@@ -35,7 +35,7 @@
       <p>
         <%= t("preferences.ignore_organisations") %>
       </p>
-      <%= form.input :ignored_organisations_string, label: t("preferences.ignored_organisations"), input_html: {class: "pull-left"} %>
+      <%= form.input :ignored_organisations_string, label: t("preferences.ignored_organisations"), placeholder: "e.g. 24pullrequests, alphagov", input_html: {class: "pull-left"} %>
     </div>
     <div class="col-md-12">
       <h2 class="text-center">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -310,7 +310,7 @@ en:
       If you regularly contribute to public repositories that you don't want to track
       on this site, add the organisation name here. You can add multiple organisations
       separated by commas. This can be useful if you code in the open at work, or
-      maintain an open source repository yourself. Example: "24pullrequests, alphagov"
+      maintain an open source repository yourself.
   preferred_languages: Preferred Languages
   projects:
     admin:


### PR DESCRIPTION
Add placeholder text to the 'Ignored Organisations' form in user preferences to match the style of the other forms on the site.