### PR TITLE
Show pull requests that a user has merged this year

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,6 +12,7 @@ class UsersController < ApplicationController
   def show
     @user      = User.find_by_nickname!(params[:id])
     @calendar  = Calendar.new(Gift.giftable_dates(current_year), @user.gifts.year(current_year))
+    @merged_pull_requests = @user.merged_pull_requests.year(current_year).latest(nil)
     respond_with @user
   end
 

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -1,5 +1,6 @@
 class PullRequest < ApplicationRecord
   belongs_to :user
+  belongs_to :merger, class_name: 'User', foreign_key: :merged_by_id, primary_key: :uid
   after_save { if user then user.update_pull_request_count end }
   after_destroy { if user then user.update_pull_request_count end }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,8 @@ class User < ApplicationRecord
 
   has_many :archived_pull_requests
 
+  has_many :merged_pull_requests, class_name: 'PullRequest', foreign_key: :merged_by_id, primary_key: :uid
+
   scope :by_language, ->(language) { joins(:skills).where('lower(language) = ?', language.downcase) }
   scope :with_any_pull_requests, -> { where('users.pull_requests_count > 0') }
   scope :random, -> { order("RANDOM()") }

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -77,6 +77,11 @@
         <li>
           <a data-toggle="tab" href="#pull_requests">Pull Requests</a>
         </li>
+        <% if @merged_pull_requests.any? %>
+        <li>
+          <a data-toggle="tab" href="#merged_pull_requests">Merges</a>
+        </li>
+        <% end %>
         <% PAST_YEAR.downto(LAUNCH_YEAR) do |year| %>
           <li>
             <a data-toggle="tab" href="#<%= year %>">
@@ -91,6 +96,9 @@
         </div>
         <div class="tab-pane" id="pull_requests">
           <%= render partial: 'users/pull_request', collection: @user.pull_requests_ignoring_organisations.year(current_year).latest(nil), cache: true %>
+        </div>
+        <div class="tab-pane" id="merged_pull_requests">
+          <%= render @merged_pull_requests, cache: true %>
         </div>
         <% PAST_YEAR.downto(LAUNCH_YEAR) do |year| %>
           <div class="tab-pane" id="<%= year %>">


### PR DESCRIPTION
As part of working towards fixing https://github.com/24pullrequests/24pullrequests/issues/1611, let's start showing which pull request a user has merged (if any) on their profiles:

![screen shot 2016-12-09 at 10 41 53 am](https://cloud.githubusercontent.com/assets/1060/21046364/47e9ea28-bdfc-11e6-9296-e7093dc213fd.png)

n.b. The tab doesn't show if you've not merged any pull requests this December.