### PR TITLE
Convert User#uid field to integer to allow joining with id columns

### DIFF
--- a/db/migrate/20161209105217_change_uids_to_integer.rb
+++ b/db/migrate/20161209105217_change_uids_to_integer.rb
@@ -1,0 +1,5 @@
+class ChangeUidsToInteger < ActiveRecord::Migration[5.0]
+  def change
+    change_column :users, :uid, 'integer USING CAST(uid AS integer)'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161202190959) do
+ActiveRecord::Schema.define(version: 20161209105217) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -140,7 +140,6 @@ ActiveRecord::Schema.define(version: 20161202190959) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "uid",                                                           null: false
     t.string   "provider",                                                      null: false
     t.string   "nickname",                                                      null: false
     t.string   "email"
@@ -150,6 +149,7 @@ ActiveRecord::Schema.define(version: 20161202190959) do
     t.string   "token"
     t.string   "email_frequency"
     t.integer  "pull_requests_count",                           default: 0
+    t.integer  "uid",                                                                       null: false
     t.datetime "last_sent_at"
     t.string   "twitter_token"
     t.string   "twitter_secret"


### PR DESCRIPTION
Following on from https://github.com/24pullrequests/24pullrequests/pull/1708, changing the uid field to integer allows for easy joining across the pull request table to find the most prolific mergers for https://github.com/24pullrequests/24pullrequests/issues/1611