### PR TITLE
Added top mergers page

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -5,6 +5,7 @@ class StaticController < ApplicationController
     @users = User.with_any_pull_requests.random.limit(24)
     @orgs = Organisation.with_any_pull_requests.random.limit(24)
     @pull_requests = PullRequest.year(current_year).order('created_at desc').limit(6)
+    @mergers = User.mergers(current_year).random.page(1).per(24)
   end
 
   def about

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,7 @@ class UsersController < ApplicationController
   end
 
   def mergers
-    @users = User.mergers.page params[:page]
+    @users = User.mergers(current_year).page params[:page]
     respond_with @users
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,7 @@ class UsersController < ApplicationController
   end
 
   def mergers
-    @users = User.mergers(current_year).page params[:page]
+    @users = User.mergers(current_year).order("merged_pull_requests_count DESC").page params[:page]
     respond_with @users
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :ensure_logged_in, only: [:projects]
 
   respond_to :html, :json
-  respond_to :js, only: :index
+  respond_to :js, only: [:index, :mergers]
 
   def index
     @users = User.order('pull_requests_count desc, nickname asc').page params[:page]
@@ -18,5 +18,10 @@ class UsersController < ApplicationController
 
   def projects
     @projects = current_user.projects.order('inactive desc')
+  end
+
+  def mergers
+    @users = User.mergers.page params[:page]
+    respond_with @users
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,8 +46,7 @@ class User < ApplicationRecord
     joins(:merged_pull_requests).
       where('EXTRACT(year FROM pull_requests.created_at) = ?', year).
       group('users.id').
-      select("users.*, count(pull_requests.id) AS merged_pull_requests_count").
-      order("merged_pull_requests_count DESC")
+      select("users.*, count(pull_requests.id) AS merged_pull_requests_count")
   end
 
   def assign_from_auth_hash(hash)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,9 +42,9 @@ class User < ApplicationRecord
     create!(AuthHash.new(hash).user_info)
   end
 
-  def self.mergers
+  def self.mergers(year = CURRENT_YEAR)
     joins(:merged_pull_requests).
-      where('EXTRACT(year FROM pull_requests.created_at) = ?', CURRENT_YEAR).
+      where('EXTRACT(year FROM pull_requests.created_at) = ?', year).
       group('users.id').
       select("users.*, count(pull_requests.id) AS merged_pull_requests_count").
       order("merged_pull_requests_count DESC")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,14 @@ class User < ApplicationRecord
     create!(AuthHash.new(hash).user_info)
   end
 
+  def self.mergers
+    joins(:merged_pull_requests).
+      where('EXTRACT(year FROM pull_requests.created_at) = ?', CURRENT_YEAR).
+      group('users.id').
+      select("users.*, count(pull_requests.id) AS merged_pull_requests_count").
+      order("merged_pull_requests_count DESC")
+  end
+
   def assign_from_auth_hash(hash)
     # do not update the email address in case the user has updated their
     # email prefs and used a new email

--- a/app/views/static/homepage.html.erb
+++ b/app/views/static/homepage.html.erb
@@ -132,6 +132,19 @@
       </div>
     </div>
   </div>
+  <div class="row avatar-block maintainers">
+    <div class="block">
+      <h3 class="block-title">
+        <%= number_with_delimiter @mergers.total_count %>
+        Maintainers have merged pull requests in <%= current_year %>
+      </h3>
+      <p>These are the people who review and accept your pull requests.</p>
+      <%= link_to t("view_all"), mergers_path, :class => 'btn btn-default btn-sm' %>
+      <ul class="avatar-list avatar-list-lg clearfix">
+        <%= render partial: 'users/merger', collection: @mergers, as: :user %>
+      </ul>
+    </div>
+  </div>
 </div>
 <div class="container">
   <div class="row">

--- a/app/views/users/_merger.html.erb
+++ b/app/views/users/_merger.html.erb
@@ -1,0 +1,10 @@
+<li class="avatar-cell">
+  <%= link_to user_path(user.nickname), class: "avatar-link" do %>
+    <%= image_tag(user.avatar_url(200), alt: user.nickname, class: "avatar-img") %>
+    <div class="username"><%= user.nickname %></div>
+    <span class="pr-badge">
+      <%= octicon "git-pull-request", :height => 9 %>
+      <%= user.merged_pull_requests_count %>
+    </span>
+  <% end %>
+</li>

--- a/app/views/users/mergers.html.erb
+++ b/app/views/users/mergers.html.erb
@@ -1,0 +1,14 @@
+<div class="row clearfix fullwidth-panel">
+  <div class="col-md-12">
+    <h3>
+      <%= number_with_delimiter @users.total_count %>
+      Users who've merged pull requests in <%= current_year %>
+    </h3>
+    <div class="js-user-pagination">
+      <ul class="clearfix avatar-list avatar-list-lg js-user-list">
+        <%= render partial: 'merger', collection: @users, as: :user %>
+      </ul>
+      <%= link_to_next_page @users, t("more"), remote: true, class: 'btn btn-success more' %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/mergers.html.erb
+++ b/app/views/users/mergers.html.erb
@@ -2,7 +2,7 @@
   <div class="col-md-12">
     <h3>
       <%= number_with_delimiter @users.total_count %>
-      Users who've merged pull requests in <%= current_year %>
+      Maintainers who've merged pull requests in <%= current_year %>
     </h3>
     <div class="js-user-pagination">
       <ul class="clearfix avatar-list avatar-list-lg js-user-list">

--- a/app/views/users/mergers.js.erb
+++ b/app/views/users/mergers.js.erb
@@ -1,0 +1,14 @@
+(function($users) {
+  var $new = $("<%= escape_javascript(render(partial: 'merger', collection: @users, as: :user)) %>").find("a[rel=tooltip]").tooltip().end();
+
+  $users.find('.js-user-list')
+        .append($new)
+
+  $users.find(".more")
+        .replaceWith(
+          "<%= escape_javascript(link_to_next_page @users,
+                                                 t('more'),
+                                                 remote: true,
+                                                 class: 'btn btn-success more') %>"
+        );
+})($(".js-user-pagination"));

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Tfpullrequests::Application.routes.draw do
 
   resources :organisations, only: [:show, :index]
 
-  get '/mergers', to: 'users#mergers'
+  get '/mergers', to: 'users#mergers', as: :mergers
   get '/users/:id', to: 'users#show'
 
   resources :events

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Tfpullrequests::Application.routes.draw do
 
   resources :organisations, only: [:show, :index]
 
+  get '/mergers', to: 'users#mergers'
   get '/users/:id', to: 'users#show'
 
   resources :events


### PR DESCRIPTION
Adds a page that lists people who've merged a pull request that was opened as part of 24pullrequests, ordered by most merged, related to https://github.com/24pullrequests/24pullrequests/issues/1611

![screen shot 2016-12-09 at 12 18 09 pm](https://cloud.githubusercontent.com/assets/1060/21048891/9009c5be-be09-11e6-94a8-4a789c5b22e9.png)

Also works with 2015 data:

![screen shot 2016-12-09 at 12 17 29 pm](https://cloud.githubusercontent.com/assets/1060/21048899/9b2dcd14-be09-11e6-9633-b30adaeb31e0.png)
