### PR TITLE
R.I.P. CURRENT_YEAR

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_year
-    @year ||= (params[:year].try(:to_i) || CURRENT_YEAR)
+    @year ||= (params[:year].try(:to_i) || Tfpullrequests::Application.current_year)
   end
 
   def current_user

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -76,7 +76,7 @@ class DashboardsController < ApplicationController
   end
 
   def giftable_range?
-    today > Date.new(CURRENT_YEAR, 12, 1) && today < Date.new(CURRENT_YEAR, 12, 24)
+    today > Date.new(Tfpullrequests::Application.current_year, 12, 1) && today < Date.new(Tfpullrequests::Application.current_year, 12, 24)
   end
 
   def set_email_preferences

--- a/app/helpers/count_helper.rb
+++ b/app/helpers/count_helper.rb
@@ -4,7 +4,7 @@ module CountHelper
   end
 
   def pull_request_count_for_language
-    PullRequest.year(CURRENT_YEAR).by_language(@language).count
+    PullRequest.year(Tfpullrequests::Application.current_year).by_language(@language).count
   end
 
   def user_count_for_language
@@ -13,7 +13,7 @@ module CountHelper
 
   def pull_request_count
     return pull_request_count_for_language if @language
-    PullRequest.year(CURRENT_YEAR).count
+    PullRequest.year(Tfpullrequests::Application.current_year).count
   end
 
   def user_count

--- a/app/models/gift.rb
+++ b/app/models/gift.rb
@@ -21,7 +21,7 @@ class Gift < ApplicationRecord
   delegate :title, :issue_url, to: :pull_request_with_archive, prefix: :pull_request
 
   def pull_request_with_archive
-    date.year == CURRENT_YEAR ? pull_request : archived_pull_request
+    date.year == Tfpullrequests::Application.current_year ? pull_request : archived_pull_request
   end
 
   scope :year, -> (year) { where('EXTRACT(year FROM "created_at") = ?', year) }
@@ -34,7 +34,7 @@ class Gift < ApplicationRecord
     where(user_id: user_id, date: date).first
   end
 
-  def self.giftable_dates(year = CURRENT_YEAR)
+  def self.giftable_dates(year = Tfpullrequests::Application.current_year)
     1.upto(24).map { |day| Date.new(year, 12, day) }
   end
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -34,6 +34,6 @@ class Organisation < ApplicationRecord
   end
 
   def update_pull_request_count
-    update_attribute(:pull_request_count, pull_requests.year(CURRENT_YEAR).count)
+    update_attribute(:pull_request_count, pull_requests.year(Tfpullrequests::Application.current_year).count)
   end
 end

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -21,8 +21,8 @@ class PullRequest < ApplicationRecord
     where.not("repo_name ~* ?", %{^(#{excluded_organisations.join("|")})/})
   }
 
-  EARLIEST_PULL_DATE = Date.parse("01/12/#{CURRENT_YEAR}").midnight
-  LATEST_PULL_DATE   = Date.parse("25/12/#{CURRENT_YEAR}").midnight
+  EARLIEST_PULL_DATE = Date.parse("01/12/#{Tfpullrequests::Application.current_year}").midnight
+  LATEST_PULL_DATE   = Date.parse("25/12/#{Tfpullrequests::Application.current_year}").midnight
 
   class << self
     def active_users(year)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,7 @@ class User < ApplicationRecord
     create!(AuthHash.new(hash).user_info)
   end
 
-  def self.mergers(year = CURRENT_YEAR)
+  def self.mergers(year = Tfpullrequests::Application.current_year)
     joins(:merged_pull_requests).
       where('EXTRACT(year FROM pull_requests.created_at) = ?', year).
       group('users.id').
@@ -192,7 +192,7 @@ class User < ApplicationRecord
 
   def unspent_pull_requests
     gifted_pull_requests = gifts.map(&:pull_request)
-    pull_requests_ignoring_organisations.year(CURRENT_YEAR).reject { |pr| gifted_pull_requests.include?(pr) }
+    pull_requests_ignoring_organisations.year(Tfpullrequests::Application.current_year).reject { |pr| gifted_pull_requests.include?(pr) }
   end
 
   def needs_setup?
@@ -210,7 +210,7 @@ class User < ApplicationRecord
   end
 
   def update_pull_request_count
-    update_attribute(:pull_requests_count, pull_requests.year(CURRENT_YEAR).for_aggregation.count)
+    update_attribute(:pull_requests_count, pull_requests.year(Tfpullrequests::Application.current_year).for_aggregation.count)
   end
 
   def lat_lng

--- a/app/views/application/_finished.html.erb
+++ b/app/views/application/_finished.html.erb
@@ -1,20 +1,20 @@
 <div class="alert alert-info">
   <h2>
     24 Pull Requests is finished for
-    <%= CURRENT_YEAR %>
+    <%= Tfpullrequests::Application.current_year %>
   </h2>
   <p>
-    In <%= CURRENT_YEAR %>, over 24 days,
+    In <%= Tfpullrequests::Application.current_year %>, over 24 days,
     <b>
-      <%= number_with_delimiter contributors_in(CURRENT_YEAR) %>
+      <%= number_with_delimiter contributors_in(Tfpullrequests::Application.current_year) %>
     </b>
     developers submitted
     <b>
-      <%= number_with_delimiter pull_requests_in(CURRENT_YEAR) %>
+      <%= number_with_delimiter pull_requests_in(Tfpullrequests::Application.current_year) %>
     </b>
     pull requests to
     <b>
-      <%= number_with_delimiter projects_in(CURRENT_YEAR) %>
+      <%= number_with_delimiter projects_in(Tfpullrequests::Application.current_year) %>
     </b>
     different open source projects.
   </p>
@@ -49,6 +49,6 @@
   <p>Find open source pull requests that need a reviewer before merging.</p>
   <hr/>
   See you on
-  <strong>December 1st, <%= CURRENT_YEAR+1 %></strong>,
+  <strong>December 1st, <%= Tfpullrequests::Application.current_year+1 %></strong>,
   Happy Hacking!
 </div>

--- a/app/views/application/_information.html.erb
+++ b/app/views/application/_information.html.erb
@@ -1,15 +1,15 @@
 <div class="alert alert-info">
   <h3>
-    <%= t("information.title", year: CURRENT_YEAR) %>
+    <%= t("information.title", year: Tfpullrequests::Application.current_year) %>
   </h3>
   <p>
-    <%= t("information.last_year_stats", year: CURRENT_YEAR,
-      developers: contributors_in(CURRENT_YEAR),
-      pull_requests: pull_requests_in(CURRENT_YEAR),
-      projects: projects_in(CURRENT_YEAR)).html_safe %>
+    <%= t("information.last_year_stats", year: Tfpullrequests::Application.current_year,
+      developers: contributors_in(Tfpullrequests::Application.current_year),
+      pull_requests: pull_requests_in(Tfpullrequests::Application.current_year),
+      projects: projects_in(Tfpullrequests::Application.current_year)).html_safe %>
   </p>
   <p>
-    <%= t("information.get_ready", year: CURRENT_YEAR) %>
+    <%= t("information.get_ready", year: Tfpullrequests::Application.current_year) %>
   </p>
   <hr/>
   <p>

--- a/app/views/reminder_mailer/_mail_content.html.erb
+++ b/app/views/reminder_mailer/_mail_content.html.erb
@@ -10,7 +10,7 @@
 </p>
 <p>We've got some suggested projects for you to send pull requests to <%= this_time %>.</p>
 <p>
-  <% if @user.pull_requests.year(CURRENT_YEAR).any? %>
+  <% if @user.pull_requests.year(Tfpullrequests::Application.current_year).any? %>
     You can view the pull requests you've made so far at http://24pullrequests.com/dashboard/.
   <% else %>
     You haven't sent any pull requests yet. Once you send a pull request, you can view your progress at http://24pullrequests.com/dashboard/.

--- a/app/views/reminder_mailer/_mail_content.text.erb
+++ b/app/views/reminder_mailer/_mail_content.text.erb
@@ -4,7 +4,7 @@ Only <%= 25 - Time.zone.today.day %> <% if (25 - Time.zone.today.day) > 1 %>days
 
 We've got some suggested projects for you to send pull requests to <%= this_time %>
 
-<% if @user.pull_requests.year(CURRENT_YEAR).any? %>
+<% if @user.pull_requests.year(Tfpullrequests::Application.current_year).any? %>
 You can view the pull requests you've made so far at http://24pullrequests.com/dashboard/.
 <% else %>
 You haven't sent any pull requests yet. Once you send a pull request, you can view your progress at http://24pullrequests.com/dashboard/.

--- a/app/views/static/homepage.html.erb
+++ b/app/views/static/homepage.html.erb
@@ -1,6 +1,6 @@
 <div class="container block intro">
   <div class="row">
-    <% unless Time.zone.today.between?(Date.new(CURRENT_YEAR, 10, 30), Date.new(CURRENT_YEAR, 12, 24)) %>
+    <% unless Time.zone.today.between?(Date.new(Tfpullrequests::Application.current_year, 10, 30), Date.new(Tfpullrequests::Application.current_year, 12, 24)) %>
       <%= render :partial => 'finished' %>
     <% end %>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -82,7 +82,7 @@
           <a data-toggle="tab" href="#merged_pull_requests">Merges</a>
         </li>
         <% end %>
-        <% PAST_YEAR.downto(LAUNCH_YEAR) do |year| %>
+        <% ((Tfpullrequests::Application.current_year) -1).downto(LAUNCH_YEAR) do |year| %>
           <li>
             <a data-toggle="tab" href="#<%= year %>">
               <%= year %>
@@ -100,7 +100,7 @@
         <div class="tab-pane" id="merged_pull_requests">
           <%= render @merged_pull_requests, cache: true %>
         </div>
-        <% PAST_YEAR.downto(LAUNCH_YEAR) do |year| %>
+        <% ((Tfpullrequests::Application.current_year) -1).downto(LAUNCH_YEAR) do |year| %>
           <div class="tab-pane" id="<%= year %>">
             <%= render partial: 'users/pull_request', collection: @user.archived_pull_requests.year(year), cache: true %>
           </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -61,5 +61,9 @@ module Tfpullrequests
     config.exceptions_app = routes
 
     I18n.config.enforce_available_locales = false
+
+    def current_year
+      Time.current.year
+    end
   end
 end

--- a/config/initializers/tfpr.rb
+++ b/config/initializers/tfpr.rb
@@ -1,3 +1,1 @@
-CURRENT_YEAR = Time.zone.today.year
-PAST_YEAR = CURRENT_YEAR - 1
 LAUNCH_YEAR = 2012

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,7 +28,7 @@ if Rails.env.development?
   USERS = 50
   PULL_REQUESTS = (3..20)
   PROJECTS = 50
-  DECEMBER_FIRST = Time.parse("1/12/#{CURRENT_YEAR}")
+  DECEMBER_FIRST = Time.parse("1/12/#{Tfpullrequests::Application.current_year}")
 
   EVENTS = ['PullRequest-a-thon', '24 Pull Requests Hack event', 'Open Source Hackday', 'Christmas Bugmash']
 

--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -16,11 +16,11 @@ end
 
 desc 'Find all users who sent 24 pull requests'
 task continuous_sync_users: :environment do
-  users = PullRequest.year(CURRENT_YEAR)
+  users = PullRequest.year(Tfpullrequests::Application.current_year)
                      .includes(:user)
                      .map(&:user)
                      .uniq.compact.sort_by(&:id)
-                     .select { |u| u.pull_requests.year(CURRENT_YEAR).length > 23 }
+                     .select { |u| u.pull_requests.year(Tfpullrequests::Application.current_year).length > 23 }
   puts "#{users.length} users"
   users.each do |user|
     puts "#{user.nickname} - #{user.email}"

--- a/lib/tasks/pull_requests.rake
+++ b/lib/tasks/pull_requests.rake
@@ -2,11 +2,11 @@ desc 'Archive old pull requests'
 task archive_old_pull_requests: :environment do
   copy_query = 'INSERT INTO archived_pull_requests (title, issue_url, body, state, merged, created_at, repo_name, user_id, language, comments_count)
     SELECT title, issue_url, body, state, merged, created_at, repo_name, user_id, language, comments_count FROM pull_requests
-    WHERE EXTRACT(year FROM "created_at") < ' + CURRENT_YEAR.to_s
+    WHERE EXTRACT(year FROM "created_at") < ' + Tfpullrequests::Application.current_year.to_s
 
   ActiveRecord::Base.connection.execute(copy_query)
 
-  delete_query = 'DELETE FROM pull_requests WHERE EXTRACT(year FROM "created_at") < ' + CURRENT_YEAR.to_s
+  delete_query = 'DELETE FROM pull_requests WHERE EXTRACT(year FROM "created_at") < ' + Tfpullrequests::Application.current_year.to_s
 
   ActiveRecord::Base.connection.execute(delete_query)
 end
@@ -29,7 +29,7 @@ end
 desc 'Download pull requests from active users'
 task download_active_pulls: :environment do
   next unless PullRequest.in_date_range?
-  PullRequest.year(CURRENT_YEAR).select(:user_id).distinct.all.map(&:user).each do |user|
+  PullRequest.year(Tfpullrequests::Application.current_year).select(:user_id).distinct.all.map(&:user).each do |user|
     user.download_pull_requests(User.load_user.token) rescue nil
     user.gift_unspent_pull_requests! rescue nil
   end
@@ -38,7 +38,7 @@ end
 desc 'Update pull requests'
 task update_pull_requests: :environment do
   next unless PullRequest.in_date_range?
-  PullRequest.year(CURRENT_YEAR).all.find_each do |pr|
+  PullRequest.year(Tfpullrequests::Application.current_year).all.find_each do |pr|
     pr.check_state rescue nil
   end
 end

--- a/spec/controllers/gifts_controller_spec.rb
+++ b/spec/controllers/gifts_controller_spec.rb
@@ -22,7 +22,7 @@ describe GiftsController, type: :controller do
     render_views
 
     it 'should pre-fill the date when one is passed' do
-      date = "#{CURRENT_YEAR}-12-03"
+      date = "#{Tfpullrequests::Application.current_year}-12-03"
       get :new, params: {date: date}
       expect(response.body).to match(/<option selected="selected" value="#{date}">/)
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -76,7 +76,7 @@ FactoryGirl.define do
     name { 'BristolJS' }
     location { 'BristolUK' }
     url { 'http://google.com' }
-    start_time { Time.parse("1st December #{CURRENT_YEAR}") }
+    start_time { Time.parse("1st December #{Tfpullrequests::Application.current_year}") }
     latitude { 51.4 }
     longitude { -2.6 }
     description { Faker::Lorem.paragraphs.first[0..199] }

--- a/spec/models/calendar_spec.rb
+++ b/spec/models/calendar_spec.rb
@@ -3,19 +3,19 @@ require 'date'
 
 describe Calendar, type: :model do
   it 'returns an enumerator for the giftable_dates' do
-    giftable_dates = 1.upto(24).map { |day| Date.new(CURRENT_YEAR, 12, day) }
+    giftable_dates = 1.upto(24).map { |day| Date.new(Tfpullrequests::Application.current_year, 12, day) }
 
     sorted_gifts = Calendar.new(giftable_dates, [])
     expect(sorted_gifts.count).to eq(24)
   end
 
   it 'yields the right gift for the right day' do
-    the_first  = double('gift', date: Date.parse("#{CURRENT_YEAR}-12-1"))
-    the_fourth = double('gift', date: Date.parse("#{CURRENT_YEAR}-12-4"))
-    the_end    = double('gift', date: Date.parse("#{CURRENT_YEAR}-12-24"))
+    the_first  = double('gift', date: Date.parse("#{Tfpullrequests::Application.current_year}-12-1"))
+    the_fourth = double('gift', date: Date.parse("#{Tfpullrequests::Application.current_year}-12-4"))
+    the_end    = double('gift', date: Date.parse("#{Tfpullrequests::Application.current_year}-12-24"))
 
     gifts          = [the_end, the_fourth, the_first]
-    giftable_dates = 1.upto(24).map { |day| Date.new(CURRENT_YEAR, 12, day) }
+    giftable_dates = 1.upto(24).map { |day| Date.new(Tfpullrequests::Application.current_year, 12, day) }
 
     sorted_gifts = Calendar.new(giftable_dates, gifts)
     sorted_gifts = sorted_gifts.map { |_day, gift| gift }
@@ -28,7 +28,7 @@ describe Calendar, type: :model do
   end
 
   it 'knows the week day padding for the first date in the sequence' do
-    giftable_dates = [Date.new(CURRENT_YEAR, 12, 1)]
+    giftable_dates = [Date.new(Tfpullrequests::Application.current_year, 12, 1)]
 
     calendar = Calendar.new(giftable_dates, [])
     expect(calendar.start_padding).to eq(3)

--- a/spec/models/pull_request_downloader_spec.rb
+++ b/spec/models/pull_request_downloader_spec.rb
@@ -8,7 +8,7 @@ describe PullRequestDownloader, type: :model do
       double('event').tap do |event|
         allow(event).to receive(:type).and_return('PullRequestEvent')
         allow(event).to receive_message_chain(:payload, :action).and_return('opened')
-        allow(event).to receive(:[]).with('created_at').and_return("24/12/#{CURRENT_YEAR}")
+        allow(event).to receive(:[]).with('created_at').and_return("24/12/#{Tfpullrequests::Application.current_year}")
       end
     end
 

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -106,14 +106,14 @@ describe PullRequest, type: :model do
         user = create :user, nickname: 'foo'
         create(:pull_request, user: user)
 
-        expect(PullRequest.active_users(CURRENT_YEAR).map(&:nickname)).to eq(%w(foo))
+        expect(PullRequest.active_users(Tfpullrequests::Application.current_year).map(&:nickname)).to eq(%w(foo))
       end
 
       it 'prevents nils' do
         nil_user = double('PullRequest', user: nil)
         allow(nil_user).to receive(:user_id).and_return(nil)
         allow(PullRequest).to receive(:year).and_return([nil_user, nil_user])
-        expect(PullRequest.active_users(CURRENT_YEAR)).to eq([])
+        expect(PullRequest.active_users(Tfpullrequests::Application.current_year)).to eq([])
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -89,7 +89,7 @@ RSpec.configure do |config|
 
   config.before do
     allow_any_instance_of(User).to receive(:estimate_skills).and_return(nil)
-    Timecop.travel(Date.parse("12/12/#{CURRENT_YEAR}"))
+    Timecop.travel(Date.parse("12/12/#{Tfpullrequests::Application.current_year}"))
   end
 
   config.after do

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -35,13 +35,13 @@ describe 'Static pages', type: :request do
   describe 'homepage in different dates' do
     context "during December" do
       it "doesnt show the finished partial on the first day" do
-        Timecop.travel(Date.new(CURRENT_YEAR, 12, 1))
+        Timecop.travel(Date.new(Tfpullrequests::Application.current_year, 12, 1))
         visit root_path
         is_expected.to_not have_content('24 Pull Requests is finished for')
       end
 
       it "doesnt show the finished partial on the last day" do
-        Timecop.travel(Date.new(CURRENT_YEAR, 12, 24))
+        Timecop.travel(Date.new(Tfpullrequests::Application.current_year, 12, 24))
         visit root_path
         is_expected.to_not have_content('24 Pull Requests is finished for')
       end
@@ -49,7 +49,7 @@ describe 'Static pages', type: :request do
 
     context "not in December or November" do
       it "shows the finished partial" do
-        Timecop.travel(Date.new(CURRENT_YEAR, 10, 29))
+        Timecop.travel(Date.new(Tfpullrequests::Application.current_year, 10, 29))
         visit root_path
         is_expected.to have_content('24 Pull Requests is finished for')
       end

--- a/spec/services/gift_factory_spec.rb
+++ b/spec/services/gift_factory_spec.rb
@@ -27,7 +27,7 @@ describe GiftFactory do
         user.gifts.create!({
           user: user,
           pull_request: pull_request,
-          date: Date.new(CURRENT_YEAR, 12, 5)
+          date: Date.new(Tfpullrequests::Application.current_year, 12, 5)
         })
       end
 


### PR DESCRIPTION
Fix #1714 .

Eliminate that need to restart the app on the eve of the New Year to update the year.