### PR TITLE
Fix homepage.events -> homepage.event.title

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -49,7 +49,7 @@
     <% if @events.any? %>
       <div class="sidebar-block">
         <h4 class="block-title">
-          <%= t("homepage.events") %>
+          <%= t("homepage.event.title") %>
         </h4>
         <% @events.each do |event| %>
           <div class="event-item">


### PR DESCRIPTION
<img width="659" alt="2016-12-11 23 12 45" src="https://cloud.githubusercontent.com/assets/1207985/21080645/a29be73a-bff7-11e6-97ad-79f1ab837b5e.png">

I think that it is good to change to `homepage.events` -> `homepage.event.title`, because the item displayed here is the information of the event page.