### PR TITLE
Change /auth/failure route from POST to GET

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Tfpullrequests::Application.routes.draw do
   delete '/twitter/remove',         to: 'twitter#remove'
 
   match '/auth/:provider/callback', to: 'sessions#create', via: [:get, :post]
-  post '/auth/failure',             to: 'sessions#failure'
+  get '/auth/failure',             to: 'sessions#failure'
 
 
   get 'about', to: 'static#about'


### PR DESCRIPTION
Fixes #1016 and allows users to cancel the OAuth flow on Twitter's side.