### PR TITLE
Remove multi_fetch_fragments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ gem 'lodash-rails'
 gem 'typhoeus'
 gem 'sassc-rails'
 gem 'puma'
-gem 'multi_fetch_fragments'
 gem 'rack-attack'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,6 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
-    multi_fetch_fragments (0.0.17)
     multi_json (1.12.1)
     multipart-post (2.0.0)
     naught (1.1.0)
@@ -411,7 +410,6 @@ DEPENDENCIES
   launchy
   lodash-rails
   meta_request
-  multi_fetch_fragments
   newrelic_rpm
   octicons_helper
   octokit


### PR DESCRIPTION
We don't need this now as it's built into rails 5

Related to #1720