### PR TITLE
Remove default `text-decoration` from `abbr[title]` elements

### DIFF
--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -539,6 +539,9 @@ hr {
   border-bottom: 1px dashed #e3e3e3;
 }
 
+abbr[title] {
+  text-decoration: none;
+}
 
 .avatar {
   margin-top: 15px;


### PR DESCRIPTION
In Chrome `abbr[title]` elements have a `text-decoration` CSS style attached by default, but since the bootstrap version that is being used uses `border-bottom` instead, it results in a duplicate underline which this PR fixes.

Before:
<img width="99" alt="bildschirmfoto 2017-12-01 um 12 11 39" src="https://user-images.githubusercontent.com/141300/33480371-f127ba36-d690-11e7-8195-4f9a12db6fb8.png">

After:
<img width="99" alt="bildschirmfoto 2017-12-01 um 12 11 44" src="https://user-images.githubusercontent.com/141300/33480372-f13ffaba-d690-11e7-9cf4-8a3700187721.png">
