### PR TITLE
Pluralize i18n pull request count on user profiles

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -367,9 +367,9 @@ en:
       pull requests or merged pull requests. Bah humbug!"
     organisations: Member of...
     pull_request_count:
-      one: "%{user} has made %{count} total pull request so far in Christmas
+      one: "%{user} has made %{count} pull request so far in Christmas
       %{year}"
-      other: "%{user} has made %{count} total pull requests so far in Christmas
+      other: "%{user} has made %{count} pull requests so far in Christmas
       %{year}"
   view_all: View All
   welcome: Welcome, %{user}!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -366,7 +366,10 @@ en:
     grinchy_message: "%{user} is being a grinch for Christmas %{year} with no gifted
       pull requests or merged pull requests. Bah humbug!"
     organisations: Member of...
-    pull_request_count: "%{user} has made %{count} total pull requests so far in Christmas
+    pull_request_count:
+      one: "%{user} has made %{count} total pull request so far in Christmas
+      %{year}"
+      other: "%{user} has made %{count} total pull requests so far in Christmas
       %{year}"
   view_all: View All
   welcome: Welcome, %{user}!

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -46,7 +46,7 @@ describe 'Users', type: :request do
         it 'has pull requests' do
           click_on 'Profile'
 
-          is_expected.to have_content 'akira has made 2 total pull requests ' \
+          is_expected.to have_content 'akira has made 2 pull requests ' \
           "so far in Christmas #{Time.zone.now.year}"
 
           is_expected.to have_link gift.pull_request.title
@@ -61,7 +61,7 @@ describe 'Users', type: :request do
           it 'filters out repos for ignored organisations but still allows gifts' do
             click_on 'Profile'
 
-            is_expected.to have_content 'akira has made 1 total pull request ' \
+            is_expected.to have_content 'akira has made 1 pull request ' \
               "so far in Christmas #{Time.zone.now.year}"
 
             is_expected.to have_link "Moar foos"

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -61,7 +61,7 @@ describe 'Users', type: :request do
           it 'filters out repos for ignored organisations but still allows gifts' do
             click_on 'Profile'
 
-            is_expected.to have_content 'akira has made 1 total pull requests ' \
+            is_expected.to have_content 'akira has made 1 total pull request ' \
               "so far in Christmas #{Time.zone.now.year}"
 
             is_expected.to have_link "Moar foos"


### PR DESCRIPTION
I noticed that the pull request count isn't properly "pluralized" on user profiles e.g. [@leereilly](https://24pullrequests.com/users/leereilly) 🔎 

![screen shot 2017-12-02 at 10 37 01 am](https://user-images.githubusercontent.com/121322/33518648-462e4a7e-d74d-11e7-86ca-1c327748b10f.png)

I _believe_ this is the standard way to handle it with i18n text in YAML files per the [Rails docs](http://guides.rubyonrails.org/i18n.html#pluralization)? 🤔 