### PR TITLE
refactor: move home url to config

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,7 +49,7 @@ module ApplicationHelper
   end
 
   def contributing_url(type = 'html')
-    url = 'http://24pullrequests.com/contributing'
+    url = "#{Rails.configuration.home_url}/contributing"
     return url if type == 'text'
     link_to url, url
   end
@@ -61,13 +61,13 @@ module ApplicationHelper
   end
 
   def preferences_url(type = 'html')
-    url = 'http://24pullrequests.com/preferences'
+    url = "#{Rails.configuration.home_url}/preferences"
     return url if type == 'text'
     link_to url, url
   end
 
   def user_unsubscribe_url(user, type = 'html')
-    url = "http://24pullrequests.com/users/unsubscribe/#{user.unsubscribe_token}"
+    url = "#{Rails.configuration.home_url}/users/unsubscribe/#{user.unsubscribe_token}"
     return url if type == 'text'
     link_to url, url
   end

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -5,7 +5,7 @@
   -->
   <meta content="24 Pull Requests" property="og:title"/>
   <meta content="website" property="og:type"/>
-  <meta content="http://24pullrequests.com/" property="og:url"/>
+  <meta content="<%= Rails.configuration.home_url%>" property="og:url"/>
   <meta content="<%= root_url %><%= image_path('24pr-logo.jpg') %>" property="og:image"/>
   <meta content="24 Pull Requests is a yearly initiative to encourage developers around the world to send 24 pull requests between December 1st and December 24th." property="og:description"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/app/views/confirmation_mailer/confirmation.html.erb
+++ b/app/views/confirmation_mailer/confirmation.html.erb
@@ -1,7 +1,7 @@
 <p>Hi <%= @user.nickname %>,</p>
 <p>
   You entered this email address as your contact address for 24pullrequests.com. Please confirm this by clicking the following link:
-  <% confirm_link = "http://24pullrequests.com/confirm/#{@user.confirmation_token}" %>
+  <% confirm_link = "#{Rails.configuration.home_url}/confirm/#{@user.confirmation_token}" %>
   <a>
     <%= link_to confirm_link, confirm_link %>
   </a>

--- a/app/views/confirmation_mailer/confirmation.text.erb
+++ b/app/views/confirmation_mailer/confirmation.text.erb
@@ -2,6 +2,6 @@ Hi <%= @user.nickname %>,
 
 You entered this email address as your contact address for 24pullrequests.com. Please confirm this by clicking the link below:
 
-http://24pullrequests.com/confirm/<%= @user.confirmation_token %>
+<%= "#{Rails.configuration.home_url}/confirm/#{@user.confirmation_token}" %>
 
 If you didn't add or change your email on 24pullrequests.com recently then please ignore this email.

--- a/app/views/errors/internal.html.erb
+++ b/app/views/errors/internal.html.erb
@@ -2,7 +2,7 @@
   <%= image_tag 'sad_tree.png' %>
   <h1>We're sorry, but something went wrong</h1>
   <p>
-    <a href="http://24pullrequests.com/">Go back to the home page</a>
+    <a href="<%= Rails.configuration.home_url %>/">Go back to the home page</a>
     , email us at
     <a href="mailto: info@24pullrequests.com">info@24pullrequests.com</a>
     or even better.. open an issue on

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -3,7 +3,7 @@
   <h1>Nothing found</h1>
   <p>
     Still lost?
-    <a href="http://24pullrequests.com/">Go back to the home page</a>
+    <a href="<%= Rails.configuration.home_url %>">Go back to the home page</a>
     or email us at
     <a href="mailto:info@24pullrequests.com">info@24pullrequests.com</a>
   </p>

--- a/app/views/reminder_mailer/_mail_content.html.erb
+++ b/app/views/reminder_mailer/_mail_content.html.erb
@@ -11,13 +11,13 @@
 <p>We've got some suggested projects for you to send pull requests to <%= this_time %>.</p>
 <p>
   <% if @user.pull_requests.year(Tfpullrequests::Application.current_year).any? %>
-    You can view the pull requests you've made so far at http://24pullrequests.com/dashboard/.
+    You can view the pull requests you've made so far at <%= Rails.configuration.home_url %>/dashboard/.
   <% else %>
-    You haven't sent any pull requests yet. Once you send a pull request, you can view your progress at http://24pullrequests.com/dashboard/.
+    You haven't sent any pull requests yet. Once you send a pull request, you can view your progress at <%= Rails.configuration.home_url %>/dashboard/.
   <% end %>
 </p>
 <p>
-  You can customise which types of project we suggest by setting your favourite languages in the preferences area here: http://24pullrequests.com/preferences
+  You can customise which types of project we suggest by setting your favourite languages in the preferences area here: <%= Rails.configuration.home_url %>/preferences
 </p>
 <h3>Suggested projects:</h3>
 <ul>

--- a/app/views/reminder_mailer/_mail_content.text.erb
+++ b/app/views/reminder_mailer/_mail_content.text.erb
@@ -5,12 +5,12 @@ Only <%= 25 - Time.zone.today.day %> <% if (25 - Time.zone.today.day) > 1 %>days
 We've got some suggested projects for you to send pull requests to <%= this_time %>
 
 <% if @user.pull_requests.year(Tfpullrequests::Application.current_year).any? %>
-You can view the pull requests you've made so far at http://24pullrequests.com/dashboard/.
+  You can view the pull requests you've made so far at <%= Rails.configuration.home_url %>/dashboard/.
 <% else %>
-You haven't sent any pull requests yet. Once you send a pull request, you can view your progress at http://24pullrequests.com/dashboard/.
+  You haven't sent any pull requests yet. Once you send a pull request, you can view your progress at <%= Rails.configuration.home_url %>/dashboard/.
 <% end %>
 
-You can customise which types of project we suggest by setting your favourite languages in the preferences area here: http://24pullrequests.com/preferences
+You can customise which types of project we suggest by setting your favourite languages in the preferences area here: <%= Rails.configuration.home_url %>/preferences
 
 Suggested Projects
 

--- a/app/views/reminder_mailer/november.html.erb
+++ b/app/views/reminder_mailer/november.html.erb
@@ -15,7 +15,7 @@
 <p>Only you can prevent this coming to pass by giving back to the open-source community this Christmas!</p>
 <p>
   Joining in is simple - visit
-  <%= link_to '24pullrequests.com/contributing', 'http://24pullrequests.com/contributing' %>
+  <%= link_to '24pullrequests.com/contributing', "#{Rails.configuration.home_url}/contributing" %>
   <%= t("nov_reminder.how_to_contribute") %>
 </p>
 <p>
@@ -27,9 +27,9 @@
   This year we're again encouraging people to set up events and allow you to work alongside some great company.
   <br/>
   Find a list of events at
-  <%= link_to '24pullrequests.com/events', 'http://24pullrequests.com/events' %>
+  <%= link_to '24pullrequests.com/events', "#{Rails.configuration.home_url}/events" %>
   or host your own event and list it on the site:
-  <%= link_to '24pullrequests.com/events/new', 'http://24pullrequests.com/events/new' %>
+  <%= link_to '24pullrequests.com/events/new', "#{Rails.configuration.home_url}/events/new" %>
 </p>
 <p>
   We've also got our gitter chatroom for everyone to hang out in:

--- a/app/views/shared/_social_buttons.html.erb
+++ b/app/views/shared/_social_buttons.html.erb
@@ -15,7 +15,7 @@
 <% end %>
 <div class="row social-buttons">
   <div class="col-sm-2">
-    <a class="twitter-share-button" data-hashtags="24pr" data-text="24 Pull Requests - Giving back little gifts of code for Christmas" data-url="http://24pullrequests.com/" data-via="24pullrequests" href="https://twitter.com/share">Tweet</a>
+    <a class="twitter-share-button" data-hashtags="24pr" data-text="24 Pull Requests - Giving back little gifts of code for Christmas" data-url="#{Rails.configuration.home_url}/" data-via="24pullrequests" href="https://twitter.com/share">Tweet</a>
     <script>
 
       !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");
@@ -23,7 +23,7 @@
     </script>
   </div>
   <div class="col-sm-2">
-    <div class="fb-like" data-href="http://24pullrequests.com/" data-layout="button_count" data-send="false" data-show-faces="false" data-width="450"></div>
+    <div class="fb-like" data-href="#{Rails.configuration.home_url}/" data-layout="button_count" data-send="false" data-show-faces="false" data-width="450"></div>
   </div>
   <div class="col-sm-2">
     <div class="g-plusone" data-size="medium">

--- a/config/application.rb
+++ b/config/application.rb
@@ -73,5 +73,7 @@ module Tfpullrequests
         current_year - 1
       end
     end
+
+    config.home_url = 'https://24pullrequests.com'
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -36,12 +36,12 @@ describe ApplicationHelper, type: :helper do
 
   describe '#contributing_url' do
     it 'returns an anchor tag with a link to the contributing section of 24pullrequests when no type is specified' do
-      resulting_html = '<a href="http://24pullrequests.com/contributing">http://24pullrequests.com/contributing</a>'
+      resulting_html = '<a href="https://24pullrequests.com/contributing">https://24pullrequests.com/contributing</a>'
       expect(helper.contributing_url).to eql(resulting_html)
     end
 
     it 'returns just the url to the contribution section of 24pullrequests when type equals text' do
-      url = 'http://24pullrequests.com/contributing'
+      url = 'https://24pullrequests.com/contributing'
       expect(helper.contributing_url('text')).to eql(url)
     end
   end
@@ -61,12 +61,12 @@ describe ApplicationHelper, type: :helper do
 
   describe '#preferences_url' do
     it 'returns an anchor tag with a link to the preferences section of 24pullrequests when no type is specified' do
-      resulting_html = '<a href="http://24pullrequests.com/preferences">http://24pullrequests.com/preferences</a>'
+      resulting_html = '<a href="https://24pullrequests.com/preferences">https://24pullrequests.com/preferences</a>'
       expect(helper.preferences_url).to eql(resulting_html)
     end
 
     it 'returns just the url to the preferences section of 24pullrequests when type equals text' do
-      url = 'http://24pullrequests.com/preferences'
+      url = 'https://24pullrequests.com/preferences'
       expect(helper.preferences_url('text')).to eql(url)
     end
   end


### PR DESCRIPTION
This is an attempt to close: https://github.com/24pullrequests/24pullrequests/issues/2105

And sure, it's one of my 24 pull requests this year. Have a happy inception dreams tonight.

Please note: this is a rather safe refactoring, moving all hardcoded URLs into one config. The alternative is to rely on `root_url` and provide some configuration so that it would be available in mailers. If you prefer that way, let me know.