### PR TITLE
Allow events on December 24th

### DIFF
--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -75,7 +75,7 @@ $ ->
   # @TODO:
   $('.js-datetimepicker').datetimepicker(
     minDate: currentYear + '/12/01'
-    maxDate: currentYear + '/12/24'
+    maxDate: currentYear + '/12/25'
     startDate: currentYear + '/12/01'
     allowTimes: allowTimes
   )

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -15,7 +15,7 @@ class Event < ApplicationRecord
   end
 
   def validate_start_time_is_in_range
-    errors.add(:start_time, :not_in_range) unless (Time.parse('1st December')..Time.parse('24th December')).cover?(start_time)
+    errors.add(:start_time, :not_in_range) unless (Time.parse('1st December')..Time.parse('25th December')).cover?(start_time)
   end
 
   def validate_start_time_is_not_in_the_past

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -36,6 +36,13 @@ describe Event, type: :model do
       end
     end
 
+    it 'should allow events on December 24th' do
+      Timecop.freeze(Time.parse('15th December 2015 12:00')) do
+        event.start_time = Time.parse('24th December 2015 13:00')
+        expect(event.valid?).to be true
+      end
+    end
+
     context 'after 1st December' do
       it 'should not pass with a start_at within of 1st December - 24th December' do
         Timecop.freeze(Time.parse('1st December 2015')) do


### PR DESCRIPTION
Current checks prevent events on the 24th since the range check is 1-24
exclusive, making events on the 24th only possible at 12:00. This
changes the checks to allow events on the 24th as well.