### PR TITLE
Bump dependencies for oauth, rack-contrib, autoprefixer-rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.3.0)
-    autoprefixer-rails (7.2.1)
+    autoprefixer-rails (7.2.2)
       execjs
     bindex (0.5.0)
     bootstrap-sass (3.3.7)
@@ -189,7 +189,7 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
-    oauth (0.5.3)
+    oauth (0.5.4)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)
       jwt (~> 1.0)
@@ -237,7 +237,7 @@ GEM
     rack-canonical-host (0.2.3)
       addressable (> 0, < 3)
       rack (>= 1.0.0, < 3)
-    rack-contrib (2.0.0)
+    rack-contrib (2.0.1)
       rack (~> 2.0)
     rack-google-analytics (1.2.0)
       actionpack


### PR DESCRIPTION
Closes #2150, #2148, #2147 