### PR TITLE
Make organization IDs case-insensitive

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -8,7 +8,7 @@ class OrganisationsController < ApplicationController
   end
 
   def show
-    @organisation = Organisation.find_by_login(params[:id])
+    @organisation = Organisation.find_by_login!(params[:id])
     respond_with @organisation
   end
 end

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -8,7 +8,7 @@ class OrganisationsController < ApplicationController
   end
 
   def show
-    @organisation = Organisation.find_by_login!(params[:id])
+    @organisation = Organisation.find_by_login(params[:id])
     respond_with @organisation
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -19,6 +19,10 @@ class Organisation < ApplicationRecord
 
       where(login: response.login).first_or_create(params)
     end
+
+    def find_by_login(login)
+      where(['lower(login) =?', login.downcase]).take
+    end
   end
 
   def active_languages

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -20,8 +20,8 @@ class Organisation < ApplicationRecord
       where(login: response.login).first_or_create(params)
     end
 
-    def find_by_login(login)
-      where(['lower(login) =?', login.downcase]).take
+    def find_by_login!(login)
+      where(['lower(login) =?', login.downcase]).first!
     end
   end
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -86,17 +86,17 @@ describe Organisation, type: :model do
 
     context 'with valid login' do
       it 'finds organization if capitalization same' do
-        expect(Organisation.find_by_login('TestOrg')).to eq organisation
+        expect(Organisation.find_by_login!('TestOrg')).to eq organisation
       end
 
       it 'finds organization if capitalization differs' do
-        expect(Organisation.find_by_login('TESTorg')).to eq organisation
+        expect(Organisation.find_by_login!('TESTorg')).to eq organisation
       end
     end
 
     context 'with invalid login' do
       it 'does not find an organization' do
-        expect(Organisation.find_by_login('fooOrg')).to be_nil
+        expect { Organisation.find_by_login!('fooOrg') }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -80,6 +80,27 @@ describe Organisation, type: :model do
     end
   end
 
+
+  describe '#find_by_login' do
+    let!(:organisation) { create(:organisation, login: 'TestOrg') }
+
+    context 'with valid login' do
+      it 'finds organization if capitalization same' do
+        expect(Organisation.find_by_login('TestOrg')).to eq organisation
+      end
+
+      it 'finds organization if capitalization differs' do
+        expect(Organisation.find_by_login('TESTorg')).to eq organisation
+      end
+    end
+
+    context 'with invalid login' do
+      it 'does not find an organization' do
+        expect(Organisation.find_by_login('fooOrg')).to be_nil
+      end
+    end
+  end
+
   def update_pull_request_counts
     Tfpullrequests::Application.load_tasks
     Rake::Task['refresh_pull_request_counts'].execute


### PR DESCRIPTION
Organization IDs are case-insensitive on GitHub itself, so the same should probably be the case here: https://24pullrequests.com/organisations/24PullRequests should return the same page as https://24pullrequests.com/organisations/24pullrequests.