### PR TITLE
Issue #2157: Add Synchronize Pull Requests Button to Profile

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -12,7 +12,9 @@
   }
 
   .language {
-    margin-right: 8px;
+    display: inline-block;
+    padding: .35em .7em .5em;
+    margin-right: 7px;
   }
 
   .username {
@@ -29,6 +31,7 @@
 
   .btn {
     margin-left: 8px;
+    margin-bottom: 10px;
   }
 
   .octicon {

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,15 +5,23 @@
   <div class="col-sm-9 profile-details">
     <% if @user == current_user %>
       <div class="profile-actions hidden-xs">
-        <%= link_to preferences_path, class: "btn btn-default btn-sm" do %>
-          <%= octicon "gear", :height => 16 %>
-          <%= t("navigation.preferences") %>
-        <% end %>
-        <% if current_user.twitter_linked? %>
-          <%= link_to t("preferences.remove"), twitter_remove_path, method: :delete, class: 'btn btn-danger btn-sm' %>
-        <% else %>
-          <%= link_to t('twitter.link_account.text'), '/auth/twitter', :class => 'btn btn-info btn-sm', rel: 'tooltip', title: t('twitter.link_account.tooltip') %>
-        <% end %>
+        <div class="row">
+          <%= link_to preferences_path, class: "btn btn-default btn-sm" do %>
+            <%= octicon "gear", :height => 16 %>
+            <%= t("navigation.preferences") %>
+          <% end %>
+          <%= link_to pull_request_download_path, :id => 'fetch-pull-requests', :class => 'btn btn-info btn-sm', :rel => 'tooltip', :title => t('pull_request.download.tooltip') do %>
+            <%= image_tag('spinner.gif', :id => 'spinner', :alt => ' ') %>
+            <%= t('dashboard.synchronize') %>
+          <% end %>
+        </div>
+        <div class="row pull-right">
+          <% if current_user.twitter_linked? %>
+            <%= link_to t("preferences.remove"), twitter_remove_path, method: :delete, class: 'btn btn-danger btn-sm' %>
+          <% else %>
+            <%= link_to t('twitter.link_account.text'), '/auth/twitter', :class => 'btn btn-info btn-sm', rel: 'tooltip', title: t('twitter.link_account.tooltip') %>
+          <% end %>
+        </div>
       </div>
     <% end %>
     <h2 class="username"><%= @user.nickname %></h2>


### PR DESCRIPTION
Fixes #2157 

- Added a sync button to the profile page
- Moved the twitter button down to its own line
- Edited scss to fix up the line break of the buttons
- Added scss to fix up the weird line breaking issue on languages that adding a new line of buttons created. When the list of languages broke onto a new line, because of the added row of buttons in the top right, the left padding stayed up on the previous line. It does not anymore.