### PR TITLE
Suppress deprecation warnings of Active Record

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -9,7 +9,7 @@ class DashboardsController < ApplicationController
       .order('created_at desc')
       .to_a
 
-    projects      = current_user.suggested_projects.order("RANDOM()").limit(12).sort_by(&:name)
+    projects      = current_user.suggested_projects.order(Arel.sql("RANDOM()")).limit(12).sort_by(&:name)
     gifted_today  = current_user.gift_for(today)
     @events = Event.where(['start_time >= ?', Time.zone.today]).order('start_time').first(5)
 

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,7 +1,7 @@
 class StaticController < ApplicationController
   def homepage
-    @projects = Project.includes(:labels).active.order("RANDOM()").limit(6)
-    @featured_projects = Project.includes(:labels).featured.order("RANDOM()").limit(6)
+    @projects = Project.includes(:labels).active.order(Arel.sql("RANDOM()")).limit(6)
+    @featured_projects = Project.includes(:labels).featured.order(Arel.sql("RANDOM()")).limit(6)
     @users = User.with_any_pull_requests.random.limit(24)
     @orgs = Organisation.with_any_pull_requests.random.limit(24)
     @pull_requests = PullRequest.year(current_year).order('created_at desc').limit(6)

--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -26,7 +26,7 @@ class ReminderMailer < ActionMailer::Base
   private
 
   def mail_suggested_projects(user, frequency)
-    @suggested_projects = user.suggested_projects.order("RANDOM()").limit(8).sort_by(&:name)
+    @suggested_projects = user.suggested_projects.order(Arel.sql("RANDOM()")).limit(8).sort_by(&:name)
     mail :to         => user.email,
          :subject    => %([24 Pull Requests] #{frequency} Reminder),
          'X-SMTPAPI' => %({"category": "#{frequency} Reminder"})

--- a/app/models/aggregation_filter.rb
+++ b/app/models/aggregation_filter.rb
@@ -4,6 +4,6 @@ class AggregationFilter < ApplicationRecord
   def self.pull_request_filter
     where("pull_requests.user_id = aggregation_filters.user_id")
     .where("pull_requests.title ILIKE aggregation_filters.title_pattern")
-    .exists.not
+    .arel.exists.not
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -3,7 +3,7 @@ class Organisation < ApplicationRecord
   has_many :pull_requests, -> { order('created_at desc').for_aggregation }, through: :users
 
   scope :with_any_pull_requests, -> { where('organisations.pull_request_count > 0') }
-  scope :random, -> { order("RANDOM()") }
+  scope :random, -> { order(Arel.sql("RANDOM()")) }
   scope :order_by_pull_requests, -> do
     order('organisations.pull_request_count desc, organisations.login asc')
   end

--- a/app/models/project_search.rb
+++ b/app/models/project_search.rb
@@ -38,7 +38,7 @@ class ProjectSearch
   private
 
   def projects
-    @projects ||= Project.active.order('random()').page(page).per(per_page)
+    @projects ||= Project.active.order(Arel.sql('random()')).page(page).per(per_page)
   end
 
   def by_languages

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
 
   scope :by_language, ->(language) { joins(:skills).where('lower(language) = ?', language.downcase) }
   scope :with_any_pull_requests, -> { where('users.pull_requests_count > 0') }
-  scope :random, -> { order("RANDOM()") }
+  scope :random, -> { order(Arel.sql("RANDOM()")) }
 
   paginates_per 99
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -13,7 +13,7 @@ describe UsersController, type: :controller do
         get :index
       end
 
-      it { expect(assigns(:users).with(User.order('pull_requests_count desc').page(0))).to be_truthy }
+      it { expect(assigns(:users).arel.with(User.order('pull_requests_count desc').page(0))).to be_truthy }
     end
 
     context 'as json' do


### PR DESCRIPTION
This PR suppresses the following Active Record warnings.

```console
DEPRECATION WARNING: Dangerous query method (method whose arguments are
used as raw SQL) called with non-attribute argument(s):
"random()". Non-attribute arguments will be disallowed in Rails
6.0. This method should not be called with user-provided values, such as
request parameters or model attributes. Known-safe values can be passed
by wrapping them in Arel.sql(). (called from projects at /Users/koic/src/github.com/24pullrequests/24pullrequests/app/models/project_search.rb:41)
```

and

```console
DEPRECATION WARNING: Delegating exists to arel is deprecated and will be
removed in Rails 6.0. (called from pull_request_filter at
/Users/koic/src/github.com/24pullrequests/24pullrequests/app/models/aggregation_filter.rb:7)

DEPRECATION WARNING: Delegating with to arel is deprecated and will be
removed in Rails 6.0. (called from block (4 levels) in <top (required)>
at /Users/koic/src/github.com/24pullrequests/24pullrequests/spec/controllers/users_controller_spec.rb:16)
```

This patch is based on the following comment.
https://github.com/rails/rails/pull/29619#issuecomment-392583498


