### PR TITLE
Remove trailing instances of 'christmas'

### DIFF
--- a/app/views/reminder_mailer/_mail_content.html.erb
+++ b/app/views/reminder_mailer/_mail_content.html.erb
@@ -3,9 +3,9 @@
   Only
   <%= 25 - Time.zone.today.day %>
   <% if (25 - Time.zone.today.day) > 1 %>
-    days left until Christmas!
+    days left until the holiday season!
   <% else %>
-    day left until Christmas!
+    day left until the holiday season!
   <% end %>
 </p>
 <p>We've got some suggested projects for you to contribute to <%= this_time %>.</p>

--- a/app/views/reminder_mailer/_mail_content.text.erb
+++ b/app/views/reminder_mailer/_mail_content.text.erb
@@ -1,6 +1,6 @@
 Hi <%= @user.nickname %>,
 
-Only <%= 25 - Time.zone.today.day %> <% if (25 - Time.zone.today.day) > 1 %>days<%else%>day<%end%> left until Christmas!
+Only <%= 25 - Time.zone.today.day %> <% if (25 - Time.zone.today.day) > 1 %>days<%else%>day<%end%> left until the holiday season!
 
 We've got some suggested projects for you to contribute to <%= this_time %>
 

--- a/app/views/shared/_social_buttons.html.erb
+++ b/app/views/shared/_social_buttons.html.erb
@@ -15,7 +15,7 @@
 <% end %>
 <div class="row social-buttons">
   <div class="col-sm-2">
-    <a class="twitter-share-button" data-hashtags="24pr" data-text="24 Pull Requests - Giving back little gifts of code for Christmas" data-via="24pullrequests" href="https://twitter.com/share">Tweet</a>
+    <a class="twitter-share-button" data-hashtags="24pr" data-text="24 Pull Requests - Giving back to open source for the holidays" data-via="24pullrequests" href="https://twitter.com/share">Tweet</a>
     <script>
 
       !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");

--- a/app/views/thank_you_mailer/thank_you.html.erb
+++ b/app/views/thank_you_mailer/thank_you.html.erb
@@ -1,4 +1,4 @@
 <p>Hi <%= @user.nickname %>,</p>
 <p>Congratulations and thank you, you've sent 24 Pull Requests!</p>
-<p>Remember, the gift of giving doesn't stop after Christmas, keep up the good work.</p>
+<p>Remember, the gift of giving doesn't stop after the holidays, keep up the good work.</p>
 <p>See you next year!</p>

--- a/app/views/thank_you_mailer/thank_you.text.erb
+++ b/app/views/thank_you_mailer/thank_you.text.erb
@@ -2,6 +2,6 @@ Hi <%= @user.nickname %>,
 
 Congratulations and thank you, you've sent 24 Pull Requests!
 
-Remember, the gift of giving doesn't stop after Christmas, keep up the good work.
+Remember, the gift of giving doesn't stop after the holidays, keep up the good work.
 
 See you next year!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,7 +88,7 @@ en:
   contributors:
     title: Contributors
   dashboard:
-    christmas_activity: This is where you can see all the activity we’ve tracked for you in the run up to Christmas.
+    christmas_activity: This is where you can see all the activity we’ve tracked for you in the run up to the holidays.
     gift_it: Gift it!
     give_a_gift: Looks like you haven’t gifted any code today. Would you like to gift your new contributions?
     help_out: Can’t think of a project you’d like to help contribute to? We’ve put together a list of popular projects here.
@@ -107,7 +107,7 @@ en:
     notification_info: If you simply want to stop receiving email notifications you can change your  %{email_preferences_link}.
     title: Delete your account
   events:
-    details: You don’t have to hack alone this Christmas! Host a 24 Pull Requests hack event at your company, technology meetup, or in your local community. Or you can join a hack event and code together.
+    details: You don’t have to hack alone this holiday season! Host a 24 Pull Requests hack event at your company, technology meetup, or in your local community. Or you can join a hack event and code together.
     save_event: Save event
     title: Events
     admin:
@@ -161,7 +161,7 @@ en:
   homepage:
     about: What’s it all about?
     about_text: "<p>24 Pull Requests is a yearly initiative to encourage contributors around the world to send 24 pull requests between December 1st and December 24th.</p> <p>This is the site to help promote the project, highlighting why, how and where to send your contributions.</p><p>Log in with your GitHub account and we’ll track and highlight all your contributions and suggest projects to work on.</p>"
-    description: Giving back little gifts of code for Christmas
+    description: Giving back to open source for the holidays
     give_to_open_source: You’ve been benefiting from the use of open source projects all year. Now is the time to say thanks to the maintainers of those projects, and a little birdy tells me that they love receiving contributions!
     greeting: "’Tis the season"
     join_the_chat: Join the chat on Gitter, %{link_to_chat}.
@@ -169,7 +169,7 @@ en:
     q_n_a: Questions & Answers
     title: 24 Pull Requests
     event:
-      description: This year we are encouraging organisers around the world to hold 24 Pull Requests hack events. Get involved this Christmas.
+      description: This year we are encouraging organisers around the world to hold 24 Pull Requests hack events. Get involved this holiday season.
       host_an_event: Host an event
       title: Events
       view_events: View events
@@ -315,5 +315,5 @@ en:
     no_current_pr_message: "%{user} has gifted no contributions this year. <a href='https://github.com/24pullrequests/24pullrequests/blob/master/CONTRIBUTING.md'>Can we help you get started?</a>"
     organisations: Member of...
     pull_request_count:
-      one: "%{user} has made %{count} contribution so far in Christmas %{year}"
-      other: "%{user} has made %{count} contributions so far in Christmas %{year}"
+      one: "%{user} has made %{count} contribution so far during the %{year} holidays"
+      other: "%{user} has made %{count} contributions so far during the %{year} holidays"

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -45,7 +45,7 @@ describe 'Users', type: :request do
           click_on 'Profile'
 
           is_expected.to have_content 'akira has made 2 contributions ' \
-          "so far in Christmas #{Time.zone.now.year}"
+          "so far during the #{Time.zone.now.year} holidays"
 
           is_expected.to have_link gift.pull_request.title
 
@@ -60,7 +60,7 @@ describe 'Users', type: :request do
             click_on 'Profile'
 
             is_expected.to have_content 'akira has made 1 contribution ' \
-              "so far in Christmas #{Time.zone.now.year}"
+              "so far during the #{Time.zone.now.year} holidays"
 
             is_expected.to have_link "Moar foos"
             is_expected.to have_link "Hi baz"


### PR DESCRIPTION
Because 24 Pull Requests is in 20 languages now, and many of them don't celebrate it. 

We're going to need to plug through translations too...