### PR TITLE
Remove google plus sharing button

### DIFF
--- a/app/views/shared/_social_buttons.html.erb
+++ b/app/views/shared/_social_buttons.html.erb
@@ -26,21 +26,6 @@
     <div class="fb-like" data-layout="button_count" data-send="false" data-show-faces="false" data-width="450"></div>
   </div>
   <div class="col-sm-2">
-    <div class="g-plusone" data-size="medium">
-      <script>
-
-        window.___gcfg = {lang: 'en-GB'};
-
-        (function() {
-          var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
-          po.src = 'https://apis.google.com/js/plusone.js';
-          var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
-        })();
-
-      </script>
-    </div>
-  </div>
-  <div class="col-sm-2">
     <iframe src="http://ghbtns.com/github-btn.html?user=24pullrequests&repo=24pullrequests&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="95" height="20"></iframe>
   </div>
   <div class="col-sm-2">


### PR DESCRIPTION
Google plus is going away, not much point keeping it on the homepage.