### PR TITLE
An apostrophe should not be used to form plurals

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -175,7 +175,7 @@ en:
       view_events: View events
     involved:
       contributing_path: Here's our primer
-      description: "There are lots of ways to get involved in an open source project: improving doc's, designs or existing code, supporting other users, fixing, replicating or triaging issues and bugs, or adding missing features."
+      description: "There are lots of ways to get involved in an open source project: improving docs, designs or existing code, supporting other users, fixing, replicating or triaging issues and bugs, or adding missing features."
       take_a_look: New to open source?  %{contributing_path}.
       title: Get involved
     profile:


### PR DESCRIPTION
Apostrophes should *only* be used to form plurals of individual lowercase letters, as in, "I was playing scrabble, and I had a lot of e's." Words like 'doc' should never be made plural with an apostrophe-plus-s. 