### PR TITLE
Fix OpenLayers import, that are 404s

### DIFF
--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -23,8 +23,8 @@
   <%= csrf_meta_tags %>
   <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:700,400" rel="stylesheet" type="text/css">
   <%= stylesheet_link_tag "application", :media => "all" %>
-  <%= stylesheet_link_tag "//openlayers.org/en/v3.0.0/css/ol.css", :media => "all" %>
-  <%= javascript_include_tag "//openlayers.org/en/v3.0.0/build/ol.js" %>
+  <%= stylesheet_link_tag "//openlayers.org/en/v3.20.1/css/ol.css", :media => "all" %>
+  <%= javascript_include_tag "//openlayers.org/en/v3.20.1/build/ol.js" %>
   <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
   <!--[if lt IE 9]>
     <script src="http://html5shim.googlecode.com/svn/trunk/html5.js" type="text/javascript"></script>


### PR DESCRIPTION
This should fix broken maps in the events list by restoring the maps as they were. Just picking a newer minor version that is not 404ing :)

Fixes a checklist item of issue https://github.com/24pullrequests/24pullrequests/issues/2350