### PR TITLE
Improve user pagination

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
   scope :with_any_contributions, -> { where('users.contributions_count > 0') }
   scope :random, -> { order(Arel.sql("RANDOM()")) }
 
-  paginates_per 99
+  paginates_per 96
 
   accepts_nested_attributes_for :skills, reject_if: proc { |attributes| !Project::LANGUAGES.include?(attributes['language']) }
 


### PR DESCRIPTION
Since the /users page has a grid of either 4 or 8 columns I think it's
better to paginate by a number divisible by both 4 and 8, so that it
paginates nicely instead of leaving the last row incomplete.