### PR TITLE
Add link to 'inclusivity bugs' blog post

### DIFF
--- a/app/views/static/contributing.html.erb
+++ b/app/views/static/contributing.html.erb
@@ -76,6 +76,9 @@
   <li>
     <%= link_to 'A Beginner’s Very Bumpy Journey Through The World of Open Source -- this one is purely for motivational purposes', 'https://medium.freecodecamp.com/a-beginners-very-bumpy-journey-through-the-world-of-open-source-4d108d540b39#.tittxeaqv' %>
   </li>
+  <li>
+    <%= link_to 'This December — Squash Open Source Inclusion Bugs!', 'https://medium.com/@sunnydeveloper/squash-inclusion-bugs-982a3e5ee29d' %>
+  </li>
 </ul>
 <h3>Other ways to find projects</h3>
 <p>Looking for other projects to help? Check out these great initiatives:</p>


### PR DESCRIPTION
This pull request adds on the 'Contributing' page a link to a blog post by @emmairwin on how 24 pull requests is a good vehicle for 'squashing inclusivity bugs'.