### PR TITLE
Revert "Bump oauth from 0.5.5 to 0.5.6 (#3254)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
     nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    oauth (0.5.6)
+    oauth (0.5.5)
     oauth2 (1.4.7)
       faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)


### PR DESCRIPTION
This reverts commit 6601e287d834f60b9a5976a6e11e8ad3a5a09067.