### PR TITLE
Update unsubscribe links in november emails

### DIFF
--- a/app/views/reminder_mailer/november.html.erb
+++ b/app/views/reminder_mailer/november.html.erb
@@ -28,4 +28,4 @@
   <%= link_to 'github.com/24pullrequests/24pullrequests/discussions', 'https://github.com/24pullrequests/24pullrequests/discussions' %>
 </p>
 <p>See you on December 1st!</p>
-<p>You can unsubscribe or change the frequency of these emails here: <%= link_to nil, preferences_url %></p>
+<%= render partial: 'reminder_mailer/sign_off_msg' %>

--- a/app/views/reminder_mailer/november.text.erb
+++ b/app/views/reminder_mailer/november.text.erb
@@ -21,4 +21,4 @@ This year we're using GitHub Discussions for everyone to hang out in and ask que
 
 See you on December 1st!
 
-You can unsubscribe or change the frequency of these emails here: https://24pullrequests.com/preferences
+<%= render partial: 'reminder_mailer/sign_off_msg' %>

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -57,4 +57,27 @@ describe ReminderMailer, type: :mailer do
       this_time: 'this week',
       next_time: 'next week'
   end
+
+  describe 'november' do
+    let(:mail) { ReminderMailer.november(user) }
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq('24 Pull Requests is starting again soon')
+    end
+
+    it 'renders the receiver email' do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it 'renders the sender email' do
+      expect(mail['From'].to_s).to eq('24 Pull Requests <info@24pullrequests.com>')
+    end
+
+
+    it 'contains periodicity in body' do
+      expect(mail.body.encoded).to match("and a Parser for a Syntax Tree.")
+      expect(mail.body.encoded).to match("You can unsubscribe to these emails here")
+      expect(mail.body.encoded).to match("unsubscribe-token")
+    end
+  end
 end


### PR DESCRIPTION
Fixes #3461

Should use the same footer as daily and weekly emails that allow for unsubscribing without logging in