### PR TITLE
add issue forms for various issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Bug report
+description: Create a report to help us improve
+title: '[BUG]: '
+labels: ['bug']
+body:
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: To Reproduce
+      description: |
+        Steps to reproduce the behavior.
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Screenshot/ Video
+      description: If applicable, add screenshots to help explain your problem.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Gitter community support
+    url: https://gitter.im/24pullrequests/24pullrequests
+    about: Need any help? Found any bug? Please chat with us via Gitter.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,23 @@
+name: Documentation
+description: Request an update to invalid/outdated documentation
+title: "[DOC]: "
+labels: ['documentation']
+body:
+  - type: textarea
+    attributes:
+      label: What is incorrect in the documentation?
+      description: Please explain the information that is incorrect in the documentation, and why you think it needs to be updated.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What should that text say?
+      description: Provide the information that the documentation should actually contain instead of the incorrect content.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this inaccuracy?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest an idea for this project
+title: '[FEATURE]: '
+labels: ['enhancement']
+body:
+  - type: textarea
+    attributes:
+      label: Would you like to have a new feature? Please describe.
+      description: A clear and concise description of what the feature is
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: How would this feature be beneficial for the project
+      description: A clear and concise description about the importance of the feature
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,21 @@
+name: Other
+description: Use this for any other issues. PLEASE do not create blank issues
+title: "[OTHER]: "
+body:
+  - type: markdown
+    attributes:
+      value: "# Other issue"
+  - type: textarea
+    id: issuedescription
+    attributes:
+      label: What would you like to share?
+      description: Provide a clear and concise explanation of your issue.
+    validations:
+      required: true
+  - type: textarea
+    id: extrainfo
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this issue?
+    validations:
+      required: false


### PR DESCRIPTION
Fixes #3474 

I have added  
-  `bug_report.yml`
-  `feature_request.yml`
- `documentation.yml` and
- `other.yml` 
issue form template file to `.github/ISSUE_TEMPLATE` folder.

Also added a `config.yml` file to stop users from opening blank issue. I have also provided the link for 24PullRequests community on Gitter.