### PR TITLE
Refreshing links and some other admin

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Gitter community support
-    url: https://gitter.im/24pullrequests/24pullrequests
-    about: Need any help? Found any bug? Please chat with us via Gitter.
+  - name: Community support
+    url: https://github.com/24pullrequests/24pullrequests/discussions
+    about: Need any help? Found any bug? Please chat with us in GitHub Discussions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,16 @@ Want to contribute to 24 Pull Requests? That's great! Here are a couple of guide
 
 #### Overview
 
-* [Contribution workflow](#contribution-workflow)  
-* [Setup instructions](#setup-instructions)  
-* [Setup using Vagrant](#setup-using-vagrant)  
-* [Reporting a bug](#reporting-a-bug)  
-* [Contributing to an existing issue](#contributing-to-an-existing-issue)  
-* [Our labels](#our-labels)  
-* [Additional info](#additional-info)  
+- [Contributing to 24 Pull Requests](#contributing-to-24-pull-requests)
+      - [Overview](#overview)
+  - [Contribution workflow](#contribution-workflow)
+  - [Setup instructions](#setup-instructions)
+  - [Reporting a bug](#reporting-a-bug)
+  - [Contributing to an existing issue](#contributing-to-an-existing-issue)
+    - [Finding an issue to work on](#finding-an-issue-to-work-on)
+    - [Making your contribution](#making-your-contribution)
+  - [Our labels](#our-labels)
+  - [Additional info](#additional-info)
 
 ## Contribution workflow
 
@@ -31,28 +34,28 @@ So you've found a bug, and want to help us fix it? Before filing a bug report, p
 * How can the error be reproduced?
 * If possible, please also provide an error message or a screenshot to illustrate the problem
 
-If you want to be really thorough, there is a great overview on Stack Overflow of [what you should consider when reporting a bug](http://stackoverflow.com/questions/240323/how-to-report-bugs-the-smart-way).
+If you want to be really thorough, there is a great overview on Stack Overflow of [what you should consider when reporting a bug](https://stackoverflow.com/questions/240323/how-to-report-bugs-the-smart-way).
 
-It goes without saying that you're welcome to help investigate further and/or find a fix for the bug. If you want to do so, just mention it in your bug report and offer your help!  
+It goes without saying that you're welcome to help investigate further and/or find a fix for the bug. If you want to do so, just mention it in your bug report and offer your help!
 
 ## Contributing to an existing issue
 
 ### Finding an issue to work on
 
-We've got a few open issues and are always glad to get help on that front. You can view the list of issues [here](https://github.com/24pullrequests/24pullrequests/issues). Most of the issues are labelled, so you can use the labels to get an idea of which issue could be a good fit for you. (Here's [a good article](https://medium.freecodecamp.com/finding-your-first-open-source-project-or-bug-to-work-on-1712f651e5ba) on how to find your first bug to fix).
+We've got a few open issues and are always glad to get help on that front. You can view the list of issues [here](https://github.com/24pullrequests/24pullrequests/issues). Most of the issues are labelled, so you can use the labels to get an idea of which issue could be a good fit for you. (Here's [a good article](https://www.freecodecamp.org/news/finding-your-first-open-source-project-or-bug-to-work-on-1712f651e5ba/) on how to find your first bug to fix).
 
 Before getting to work, take a look at the issue and at the conversation around it. Has someone already offered to work on the issue? Has someone been assigned to the issue? If so, you might want to check with them to see whether they're still actively working on it.
 
 If the issue is a few months old, it might be a good idea to write a short comment to double-check that the issue or feature is still a valid one to jump on.
 
 Feel free to ask for more detail on what is expected: are there any more details or specifications you need to know?
-And if at any point you get stuck: don't hesitate to ask for help.  
+And if at any point you get stuck: don't hesitate to ask for help.
 
-### Making your contribution  
+### Making your contribution
 
-We've outlined the contribution workflow [here](#contribution-workflow). If you're a first-timer, don't worry! GitHub has a ton of guides to help you through your first pull request: You can find out more about pull requests [here](https://help.github.com/articles/about-pull-requests/) and about creating a pull request [here](https://help.github.com/articles/creating-a-pull-request/).
+We've outlined the contribution workflow [here](#contribution-workflow). If you're a first-timer, don't worry! GitHub has a ton of guides to help you through your first pull request: You can find out more about pull requests [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) and about creating a pull request [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
 
-## Our labels  
+## Our labels
 
 - **beginner**: One of our most important kinds of issues! These issues have been marked by the maintainers as small, low-impact changes and fixes, ideal for those just dipping their toes for the first time into the world of contributing to Open Source software. These are by no means any less important than any other issues! We'd appreciate if our more experienced contributors would leave these to our newer compatriots so we can be as fair as possible to everyone.
 - **blocked**: We will generally mark an issue as blocked if it requires more context for us to fix, is waiting on an updated version of a library that the issue depends on, or is waiting on a maintainer to do something before it can be answered. There may be other conditions in which we'll mark an issue as blocked, and we'll make this clear in the issue comments.
@@ -73,6 +76,6 @@ We've outlined the contribution workflow [here](#contribution-workflow). If you'
 - **visual design**: This relates to visual elements of the site that could be improved or are broken. This may be as simple as a change to a CSS colour or font size but may stretch all the way to things that do not render as expected on mobile devices. These are usually good issues for people with front-end development experience to tackle.
 - **wontfix**: This means that, after considering your issue in full, your issue is outside of the intended scope of the project and is not something we'd like to add to the codebase right now or in the future. These are used sparingly and are intended to be rare, and are never used without reasoned justification.
 
-## Additional info  
+## Additional info
 
-Especially if you're a newcomer to Open Source and you've found some little bumps along the way while contributing, we recommend you write about them. [Here](https://medium.freecodecamp.com/new-contributors-to-open-source-please-blog-more-920af14cffd)'s a great article about why writing about your experience is important; this will encourage other beginners to try their luck at Open Source, too!
+Especially if you're a newcomer to Open Source and you've found some little bumps along the way while contributing, we recommend you write about them. [Here](https://www.freecodecamp.org/news/new-contributors-to-open-source-please-blog-more-920af14cffd/) is a great article about why writing about your experience is important; this will encourage other beginners to try their luck at Open Source, too!

--- a/Readme.md
+++ b/Readme.md
@@ -10,18 +10,18 @@ This is the site to help promote the project, highlighting why, how and where to
 
 ## Table of Contents
 
-- [Get started](#get-started)
-- [Contributors](#contributors)
-- [Development](#development)
-  - [Getting Started](#getting-started)
-    - [Installing a Local Server](#installing-a-local-server)
-    - [Using Vagrant](#using-vagrant)
-  - [Tests](#tests)
-  - [Environment variables](#environment-variables)
-  - [Contributing](#contributing)
+- [24 Pull Requests](#24-pull-requests)
+  - [Table of Contents](#table-of-contents)
+  - [Get started](#get-started)
+  - [Contributors](#contributors)
+  - [Development](#development)
+    - [Getting Started](#getting-started)
+      - [Installing a Local Server](#installing-a-local-server)
+    - [Tests](#tests)
+    - [Contributing](#contributing)
     - [Translations](#translations)
-  - [Code of Conduct](#code-of-conduct)
-- [Copyright](#copyright)
+    - [Code of Conduct](#code-of-conduct)
+  - [Copyright](#copyright)
 
 ## Get started
 
@@ -35,7 +35,8 @@ Over 180 different people have contributed to the project, you can see them all 
 ## Development
 
 The source is hosted at [GitHub](https://github.com/24pullrequests/24pullrequests).
-You can report issues/feature requests on [GitHub Issues](https://github.com/24pullrequests/24pullrequests/issues). Follow the project on Twitter [@24pullrequests](https://twitter.com/24pullrequests). People from this community also often hangout on [Gitter](https://gitter.im/24pullrequests/24pullrequests).
+
+You can report issues/feature requests on [GitHub Issues](https://github.com/24pullrequests/24pullrequests/issues). You can use [GitHub Discussions](https://github.com/24pullrequests/24pullrequests/discussions) to ask questions, follow announcements, and to propose ideas for the 24pullrequests project. Follow the project on Twitter [@24pullrequests](https://twitter.com/24pullrequests).
 
 These instructions are for working on the the [24pullrequests.com](https://24pullrequests.com) website. If you just want to be a developer who contributes PRs during the holidays, you don't need to follow these instructions! Go to https://24pullrequests.com and get involved there.
 
@@ -55,8 +56,7 @@ rbenv install 2.7.5
 rbenv global 2.7.5
 ```
 
-Next, you'll need to make sure that you have PostgreSQL installed. This can be
-done easily on OSX using [Homebrew](http://mxcl.github.io/homebrew/) or by using [http://postgresapp.com](http://postgresapp.com). Please see these [further instructions for installing Postgres via Homebrew](http://www.mikeball.us/blog/setting-up-postgres-with-homebrew/).
+Next, you'll need to make sure that you have PostgreSQL installed. This can be done easily on macOS using [Homebrew](https://brew.sh) or by using [https://postgresapp.com](https://postgresapp.com). Please see these [further instructions for installing Postgres via Homebrew](http://www.mikeball.us/blog/setting-up-postgres-with-homebrew/).
 
 ```bash
 brew install postgres
@@ -69,7 +69,7 @@ On Debian-based Linux distributions you can use apt-get to install Postgres:
 sudo apt-get install postgresql postgresql-contrib libpq-dev
 ```
 
-On Windows, you can use the [Chocolatey package manager](http://chocolatey.org/) to install Postgres:
+On Windows, you can use the [Chocolatey package manager](https://chocolatey.org/) to install Postgres:
 
 ```bash
 choco install postgresql
@@ -89,8 +89,7 @@ gem install bundler && rbenv rehash
 bundle install
 ```
 
-Once all the gems are installed, we'll need to create the databases and
-tables. Rails makes this easy through the use of "Rake" tasks.
+Once all the gems are installed, we'll need to create the databases and tables. Rails makes this easy through the use of "Rake" tasks.
 
 ```bash
 bundle exec rake db:create:all
@@ -106,8 +105,7 @@ bundle exec rake db:seed
 If you are working on anything related to the email-generation code, you can use [MailCatcher](https://github.com/sj26/mailcatcher).
 Since we use Bundler, please read the [following](https://github.com/sj26/mailcatcher#bundler) before using MailCatcher.
 
-Almost there! Now all we have to do is start up the Rails server and point
-our browser to <http://localhost:3000>
+Almost there! Now all we have to do is start up the Rails server and point our browser to <http://localhost:3000>
 
 ```bash
 bundle exec rails s
@@ -119,9 +117,7 @@ Standard RSpec/Capybara tests are used for testing the application. The tests ca
 
 You can set up the test environment with `bundle exec rake db:test:prepare`, which will create the test DB and populate its schema automatically. You don't need to do this for every test run, but it will let you easily keep up with migrations. If you find a large number of tests are failing you should probably run this.
 
-If you are using the [omniauth](https://github.com/omniauth/omniauth) environment variables
-(GITHUB_KEY, GITHUB_SECRET, TWITTER_KEY, TWITTER_SECRET)
-for **another** project, you will need to either
+If you are using the [omniauth](https://github.com/omniauth/omniauth) environment variables (`GITHUB_KEY`, `GITHUB_SECRET`, `TWITTER_KEY`, `TWITTER_SECRET`) for **another** project, you will need to either
  * unset them before running your tests or
  * reset the omniauth environment variables after creating a GitHub (omniauth) application for this project
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,7 @@ module ApplicationHelper
   end
 
   def github_button(nickname)
-    %(<iframe src="http://ghbtns.com/github-btn.html?user=#{nickname}&type=follow&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="300" height="20"></iframe>).html_safe
+    %(<iframe src="https://ghbtns.com/github-btn.html?user=#{nickname}&type=follow&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="300" height="20"></iframe>).html_safe
   end
 
   def contributors_in(year)
@@ -49,7 +49,7 @@ module ApplicationHelper
   end
 
   def twitter_url
-    'http://twitter.com/24pullrequests'
+    'https://twitter.com/24pullrequests'
   end
 
   def unconfirmed_email?

--- a/app/views/application/_finished.html.erb
+++ b/app/views/application/_finished.html.erb
@@ -31,7 +31,7 @@
     <%= t("information.help_open_source") %>
   </p>
   <h4>
-    <%= link_to 'CodeTriage', 'http://www.codetriage.com/' %>
+    <%= link_to 'CodeTriage', 'https://www.codetriage.com/' %>
   </h4>
   <p>
     <%= t("information.codetriage") %>
@@ -51,7 +51,7 @@
   </h4>
   <p>Browse open source projects with issues for beginners.</p>
   <h4>
-    <%= link_to 'Ovio.org', 'http://www.ovio.org/projects' %>
+    <%= link_to 'Ovio.org', 'https://www.ovio.org/projects' %>
   </h4>
   <p>
     <%= t("information.ovio") %>

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -21,7 +21,7 @@
     <%= content_for?(:title) ? yield(:title) : "24 Pull Requests" %>
   </title>
   <%= csrf_meta_tags %>
-  <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:700,400" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:700,400" rel="stylesheet" type="text/css">
   <%= stylesheet_link_tag "application", :media => "all" %>
   <%= stylesheet_link_tag "//openlayers.org/en/v3.20.1/css/ol.css", :media => "all" %>
   <%= javascript_include_tag "//openlayers.org/en/v3.20.1/build/ol.js" %>

--- a/app/views/application/_information.html.erb
+++ b/app/views/application/_information.html.erb
@@ -16,7 +16,7 @@
     <%= t("information.help_open_source") %>
   </p>
   <h4>
-    <%= link_to 'CodeTriage', 'http://www.codetriage.com/' %>
+    <%= link_to 'CodeTriage', 'https://www.codetriage.com/' %>
   </h4>
   <p>
     <%= t("information.codetriage") %>
@@ -28,7 +28,7 @@
     <%= t("information.issuehubio") %>
   </p>
   <h4>
-    <%= link_to 'Ovio.org', 'http://www.ovio.org/projects' %>
+    <%= link_to 'Ovio.org', 'https://www.ovio.org/projects' %>
   </h4>
   <p>
     <%= t("information.ovio") %>

--- a/app/views/static/_disabled.html.erb
+++ b/app/views/static/_disabled.html.erb
@@ -16,7 +16,7 @@
     <%= t("information.help_open_source") %>
   </p>
   <h4>
-    <%= link_to 'CodeTriage', 'http://www.codetriage.com/' %>
+    <%= link_to 'CodeTriage', 'https://www.codetriage.com/' %>
   </h4>
   <p>
     <%= t("information.codetriage") %>
@@ -38,7 +38,7 @@
     Find meaningful Open Source contribution opportunities.
   </p>
   <h4>
-    <%= link_to 'Ovio.org', 'http://www.ovio.org/projects' %>
+    <%= link_to 'Ovio.org', 'https://www.ovio.org/projects' %>
   </h4>
   <p>
     <%= t("information.ovio") %>

--- a/app/views/static/contributing.html.erb
+++ b/app/views/static/contributing.html.erb
@@ -47,34 +47,34 @@
 <h3>Other guides to contributing</h3>
 <ul>
   <li>
-    <%= link_to 'Using Pull Requests', 'https://help.github.com/articles/using-pull-requests' %>
+    <%= link_to 'About Pull Requests', 'https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests' %>
   </li>
   <li>
-    <%= link_to 'A quick guide to pull requests', 'http://beust.com/weblog/2010/09/15/a-quick-guide-to-pull-requests/' %>
+    <%= link_to 'A quick guide to pull requests', 'https://beust.com/weblog/2010/09/15/a-quick-guide-to-pull-requests/' %>
   </li>
   <li>
-    <%= link_to 'You (yes, you!) should contribute to open source', 'http://changelog.com/you-yes-you-should-contribute-to-open-source/' %>
+    <%= link_to 'You (yes, you!) should contribute to open source', 'https://changelog.com/you-yes-you-should-contribute-to-open-source/' %>
   </li>
   <li>
-    <%= link_to 'How to contribute a patch to a GitHub hosted Open Source project', 'http://www.hanselman.com/blog/GetInvolvedInOpenSourceTodayHowToContributeAPatchToAGitHubHostedOpenSourceProjectLikeCode52.aspx' %>
+    <%= link_to 'How to contribute a patch to a GitHub hosted Open Source project', 'https://www.hanselman.com/blog/GetInvolvedInOpenSourceTodayHowToContributeAPatchToAGitHubHostedOpenSourceProjectLikeCode52.aspx' %>
   </li>
   <li>
-    <%= link_to 'Contributing to Open Source on GitHub', 'https://guides.github.com/activities/contributing-to-open-source/' %>
+    <%= link_to 'Finding ways to contribute to open source on GitHub', 'https://docs.github.com/en/get-started/exploring-projects-on-github/finding-ways-to-contribute-to-open-source-on-github' %>
   </li>
   <li>
-    <%= link_to 'Welcome! Let us do some Open Source!', 'http://www.firsttimersonly.com/' %>
+    <%= link_to 'Welcome! Let us do some Open Source!', 'https://www.firsttimersonly.com/' %>
   </li>
   <li>
-    <%= link_to 'How to find your first open source bug to fix', 'https://medium.freecodecamp.com/finding-your-first-open-source-project-or-bug-to-work-on-1712f651e5ba#.9wo026gn4' %>
+    <%= link_to 'How to find your first open source bug to fix', 'https://www.freecodecamp.org/news/finding-your-first-open-source-project-or-bug-to-work-on-1712f651e5ba/#.9wo026gn4' %>
   </li>
   <li>
     <%= link_to '[For maintainers] How to attract new contributors to your open source project', 'https://medium.freecodecamp.com/how-to-attract-new-contributors-to-your-open-source-project-46f8b791d787#.lzb5gev6q' %>
   </li>
   <li>
-    <%= link_to 'Hey newbie open source contributors: please blog more.', 'https://medium.freecodecamp.com/new-contributors-to-open-source-please-blog-more-920af14cffd#.cz98nsqme' %>
+    <%= link_to 'Hey newbie open source contributors: please blog more.', 'https://www.freecodecamp.org/news/how-to-attract-new-contributors-to-your-open-source-project-46f8b791d787/#.lzb5gev6q' %>
   </li>
   <li>
-    <%= link_to 'A Beginner’s Very Bumpy Journey Through The World of Open Source -- this one is purely for motivational purposes', 'https://medium.freecodecamp.com/a-beginners-very-bumpy-journey-through-the-world-of-open-source-4d108d540b39#.tittxeaqv' %>
+    <%= link_to 'A Beginner’s Very Bumpy Journey Through The World of Open Source -- this one is purely for motivational purposes', 'https://www.freecodecamp.org/news/a-beginners-very-bumpy-journey-through-the-world-of-open-source-4d108d540b39/#.tittxeaqv' %>
   </li>
   <li>
     <%= link_to 'This December — Squash Open Source Inclusion Bugs!', 'https://medium.com/@sunnydeveloper/squash-inclusion-bugs-982a3e5ee29d' %>
@@ -83,7 +83,7 @@
 <h3>Other ways to find projects</h3>
 <p>Looking for other projects to help? Check out these great initiatives:</p>
 <h4>
-  <%= link_to 'CodeTriage', 'http://www.codetriage.com/' %>
+  <%= link_to 'CodeTriage', 'https://www.codetriage.com/' %>
 </h4>
 <p>
   <%= t("information.codetriage") %>
@@ -95,7 +95,7 @@
   <%= t("information.issuehubio") %>
 </p>
 <h4>
-  <%= link_to 'Ovio.org', 'http://www.ovio.org/projects' %>
+  <%= link_to 'Ovio.org', 'https://www.ovio.org/projects' %>
 </h4>
 <p>
   <%= t("information.ovio") %>


### PR DESCRIPTION
Primarily, updating links...

- http: -> https: where possible (NB a few sites don't seem to have TLS enabled; might consider removing them)
- OS X -> macOS in one instance
- updated links where things had moved around or relocated e.g. Homebrew page, freecodecamp
- referenced GitHub Discussions in the main `README.md` and `ISSUE_TEMPLATE.md`