### PR TITLE
Issue #3480: [FEATURE]: Add a way to edit added contribution

### DIFF
--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -535,6 +535,13 @@ footer {
   }
 }
 
+.contribution {
+  .contribution_action {
+    display: block;
+    margin-bottom: 10px;
+  }
+}
+
 hr {
   border-top: none;
   border-bottom: 1px dashed #e3e3e3;

--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -23,12 +23,12 @@ class ContributionsController < ApplicationController
 
   def edit
     @contribution = current_user.contributions.find_by_id(params[:id])
-    redirect_to root_path, notice: t('contributions.notice.not_authorized') unless @contribution.present?
+    redirect_to root_path, notice: t('contributions.notice.not_authorized') unless @contribution.present? && @contribution.can_edit?(current_user)
   end
 
   def update
     @contribution = current_user.contributions.find_by_id(params[:id])
-    redirect_to root_path, notice: t('contributions.notice.not_authorized') unless @contribution.present?
+    redirect_to root_path, notice: t('contributions.notice.not_authorized') unless @contribution.present? && @contribution.can_edit?(current_user)
     if @contribution.update(contribution_params)
       redirect_to @contribution, notice: t('contributions.notice.edit_success')
     else

--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -21,8 +21,30 @@ class ContributionsController < ApplicationController
     end
   end
 
+  def edit
+    @contribution = current_user.contributions.find_by_id(params[:id])
+    redirect_to root_path, notice: t('contributions.notice.not_authorized') unless @contribution.present?
+  end
+
+  def update
+    @contribution = current_user.contributions.find_by_id(params[:id])
+    redirect_to root_path, notice: t('contributions.notice.not_authorized') unless @contribution.present?
+    if @contribution.update(contribution_params)
+      redirect_to @contribution, notice: t('contributions.notice.edit_success')
+    else
+      render :edit
+    end
+  end
+
   def show
     @contribution = Contribution.find(params[:id])
+  end
+
+  def destroy
+    @contribution = current_user.contributions.find_by_id(params[:id])
+    redirect_to root_path, notice: t('contributions.notice.not_authorized') unless @contribution.present?
+    @contribution.destroy!
+    redirect_back(fallback_location: root_path, notice: t('contributions.notice.destroy_success'))
   end
 
   def meta

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -57,6 +57,11 @@ class Contribution < ApplicationRecord
     end
   end
 
+  def can_edit?(user)
+    return false unless user.present?
+    user_id == user.id || user.admin?
+  end
+
   def pull_request?
     state.present?
   end

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -59,7 +59,7 @@ class Contribution < ApplicationRecord
 
   def can_edit?(user)
     return false unless user.present?
-    user_id == user.id || user.admin?
+    (user_id == user.id && created_at > EARLIEST_PULL_DATE) || user.admin?
   end
 
   def pull_request?

--- a/app/views/contributions/edit.html.erb
+++ b/app/views/contributions/edit.html.erb
@@ -1,0 +1,4 @@
+<h3>
+  <%= t("contributions.edit.title") %>
+</h3>
+<%= render 'form' %>

--- a/app/views/contributions/show.html.erb
+++ b/app/views/contributions/show.html.erb
@@ -27,6 +27,11 @@
       <%= @contribution.created_at %>
     </abbr>
   </p>
+  <% if @contribution.can_edit?(current_user) && (not @contribution.pull_request?) %>
+    <br>
+    <%= link_to t("contributions.show.edit_contribution"), edit_contribution_path(@contribution), class: "btn btn-default" %>
+    <%= link_to t("contributions.show.destroy_contribution"), @contribution, data: { confirm: I18n.t("contributions.show.confirm_destroy") }, method: :delete, class: "btn btn-danger" %>
+  <% end %>
   <br>
   <p class="js-emoji">
     <%= simple_format @contribution.body %>

--- a/app/views/users/_contribution.html.erb
+++ b/app/views/users/_contribution.html.erb
@@ -1,6 +1,10 @@
 <%= cache contribution do %>
   <div class="contribution row-fluid clearfix">
-    <div class="span12">
+    <% if contribution.can_edit?(current_user) %>
+      <div class="col-md-10">
+    <% else %>
+      <div class="col-md-12">
+    <% end %>
       <h4>
         <% if contribution.pull_request? %>
           <%= link_to contribution.title, contribution.issue_url, :target => :_blank %>
@@ -33,5 +37,11 @@
         </div>
       </p>
     </div>
+    <% if contribution.can_edit?(current_user) && (not contribution.pull_request?) %>
+      <div class="col-md-2">
+        <%= link_to t("contributions.show.edit_contribution"), edit_contribution_path(contribution), class: "btn btn-default contribution_action contribution_edit" %>
+        <%= link_to t("contributions.show.destroy_contribution"), contribution, data: { confirm: I18n.t("contributions.show.confirm_destroy") }, method: :delete, class: "btn btn-danger contribution_action" %>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,7 +82,7 @@ en:
       destroy_success: Contribution removed successfully!
       edit_success: Contribution updated successfully!
       new_success: Contribution created successfully!
-      not_authorized: You can only edit contributions that you have created
+      not_authorized: You can only edit contributions that you have created this year
       not_logged_in: You must be logged in to create or edit contributions
     edit:
       title: Edit Contribution

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,18 @@ en:
         repo_name_placeholder: Open source project name
       save: Record your contribution
       title: How did you contribute to open source today?
+    show:
+      confirm_destroy: Are you sure you want to remove this contribution?
+      destroy_contribution: Remove Contribution
+      edit_contribution: Edit Contribution
+    notice:
+      destroy_success: Contribution removed successfully!
+      edit_success: Contribution updated successfully!
+      new_success: Contribution created successfully!
+      not_authorized: You can only edit contributions that you have created
+      not_logged_in: You must be logged in to create or edit contributions
+    edit:
+      title: Edit Contribution
   contributors:
     title: Contributors
   contributors_involved: Contributors already involved

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -143,7 +143,7 @@ describe Contribution, type: :model do
   end
 
   describe '.can_edit?' do
-    let(:contribution) { FactoryBot.build(:contribution) }
+    let(:contribution) { create :contribution }
 
     context 'for an admin' do
       let(:user) { mock_model(User, admin?: true) }
@@ -160,9 +160,15 @@ describe Contribution, type: :model do
     end
 
     context 'when the user is the contribution owner logged in' do
-      it 'should return true' do
+      it 'should return true when created in the current year' do
         contribution.user_id = user.id
         expect(contribution.can_edit?(user)).to be true
+      end
+
+      it 'should return false when created in a previous year' do
+        contribution.user_id = user.id
+        contribution.created_at = Faker::Date.between_except(1.year.ago, Contribution::EARLIEST_PULL_DATE, Contribution::EARLIEST_PULL_DATE)
+        expect(contribution.can_edit?(user)).to be false
       end
     end
 

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -141,4 +141,36 @@ describe Contribution, type: :model do
       end
     end
   end
+
+  describe '.can_edit?' do
+    let(:contribution) { FactoryBot.build(:contribution) }
+
+    context 'for an admin' do
+      let(:user) { mock_model(User, admin?: true) }
+
+      it 'should return true' do
+        expect(contribution.can_edit?(user)).to be true
+      end
+    end
+
+    context 'when the user is not logged in' do
+      it 'should return false' do
+        expect(contribution.can_edit?(nil)).to be false
+      end
+    end
+
+    context 'when the user is the contribution owner logged in' do
+      it 'should return true' do
+        contribution.user_id = user.id
+        expect(contribution.can_edit?(user)).to be true
+      end
+    end
+
+    context 'when the user is not the contribution owner' do
+      it 'should return false' do
+        contribution.user_id = 2
+        expect(contribution.can_edit?(user)).to be false
+      end
+    end
+  end
 end

--- a/spec/requests/contributions_spec.rb
+++ b/spec/requests/contributions_spec.rb
@@ -24,4 +24,44 @@ describe 'Contribution', type: :request do
       expect(page.all('.contribution a.image').length).to eq(1)
     end
   end
+
+  describe 'editing contributions', js: true do
+    let!(:user) { create :user }
+    let!(:contribution) { create :contribution, :user => user, :state => nil }
+
+    before do
+      login user
+    end
+
+    context 'a logged-in user' do
+      it 'should be able to edit contributions they have created' do
+        visit user_path(user)
+
+        click_on "Edit Contribution"
+
+        find(:css, '.contribution_body textarea').text "New test"
+        click_on 'Record your contribution'
+
+        should have_content 'Contribution updated successfully!'
+      end
+
+      it 'can delete a contribution' do
+        visit user_path(user)
+
+        accept_confirm do
+          click_on "Remove Contribution"
+        end
+
+        should have_content "Contribution removed successfully!"
+      end
+
+      it "should not be able to edit other user's contributions" do
+        contribution.user_id = nil
+        contribution.save
+        visit edit_contribution_path(contribution)
+
+        should have_content 'You can only edit contributions that you have created'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #3480 

* Added edit and delete functionality
* Added edit page for non-PR contributions
* Added edit and delete links to user dashboard and edit page for non-PR contributions
* Added minor styling for button spacing
* Added check for ability to edit
* Added translation for English only
* Added testing