### PR TITLE
Issue #3491: [BUG]: Small fix for view of Incorrect email message

### DIFF
--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -694,3 +694,10 @@ abbr[title] {
     float: none !important;
   }
 }
+
+.user_email {
+  .help-block {
+    @extend .col-md-8;
+    color: #a94442;
+  }
+}

--- a/app/views/dashboards/preferences.html.erb
+++ b/app/views/dashboards/preferences.html.erb
@@ -27,9 +27,7 @@
         </em>
       </p>
       <%= form.input :email_frequency, :label => t("preferences.form.email_frequency"), :collection => [[t("preferences.form.never"), 'none'], [t("preferences.form.daily"), 'daily'], [t("preferences.form.weekly"), 'weekly']], :selected => (form.object.email_frequency || 'daily') %>
-      <% if current_user.errors[:email].any? %>
-        <%= form.input :email %>
-      <% elsif current_user.email.present? && !current_user.confirmed? %>
+      <% if current_user.email.present? && !current_user.confirmed? && !current_user.errors[:email].any? %>
         <%= form.input :email, hint: t("preferences.hint.confirm_email") %>
       <% else %>
         <%= form.input :email, :label => t("preferences.form.email") %>

--- a/app/views/dashboards/preferences.html.erb
+++ b/app/views/dashboards/preferences.html.erb
@@ -27,7 +27,9 @@
         </em>
       </p>
       <%= form.input :email_frequency, :label => t("preferences.form.email_frequency"), :collection => [[t("preferences.form.never"), 'none'], [t("preferences.form.daily"), 'daily'], [t("preferences.form.weekly"), 'weekly']], :selected => (form.object.email_frequency || 'daily') %>
-      <% if current_user.email.present? && !current_user.confirmed? %>
+      <% if current_user.errors[:email].any? %>
+        <%= form.input :email %>
+      <% elsif current_user.email.present? && !current_user.confirmed? %>
         <%= form.input :email, hint: t("preferences.hint.confirm_email") %>
       <% else %>
         <%= form.input :email, :label => t("preferences.form.email") %>


### PR DESCRIPTION
Fixes #3491 

* Update logic to display either error message for email validation or the confirm email message, not both
* Minor styling fix