### PR TITLE
Handle octokit errors when syncing repos

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -120,6 +120,11 @@ class Project < ApplicationRecord
     attrs[:description] = repo[:description][0..200] if repo[:description].present?
     update(attrs)
     update_score(token)
+  rescue Octokit::NotFound, Octokit::RepositoryUnavailable, Octokit::InvalidRepository
+    # bad repository
+    update contribulator: 0, last_scored: Time.now
+  rescue Octokit::Unauthorized
+    # bad token
   end
 
   def format_url(url)


### PR DESCRIPTION
Some repositories have been deleted/made private, they should have a score of zero