### PR TITLE
Issue #3512: [FEATURE]: Tooltips for Gifts on Calendar view

### DIFF
--- a/app/views/users/_calendar.html.erb
+++ b/app/views/users/_calendar.html.erb
@@ -14,7 +14,7 @@
         <%= date.mday %>
       </span>
       <% if gift.present? %>
-        <%= link_to gift.contribution_title, gift.contribution_issue_url, :target => :_blank %>
+        <%= link_to gift.contribution_title, gift.contribution_issue_url, :title => gift.contribution_title, :target => :_blank %>
       <% end %>
     </li>
   <% end %>


### PR DESCRIPTION
Fixes #3512

* Add title attribute to gift link in _calender view

(This one seemed like a "What's the harm?" one given if you have a pull request title that fills the calendar space it does get hidden instead of the calendar space getting taller.)