### PR TITLE
Clear invalid_token flag after updating token

### DIFF
--- a/app/services/auth_hash.rb
+++ b/app/services/auth_hash.rb
@@ -17,7 +17,8 @@ class AuthHash
       gravatar_id: gravatar_id,
       name:        name,
       blog:        blog,
-      location:    location
+      location:    location,
+      invalid_token: false
     }
   end
 


### PR DESCRIPTION
Ensures that returning users who log back in with new, valid tokens are no longer marked as invalid