### PR TITLE
Bump mimemagic from 0.3.2 to 0.3.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,9 @@ GEM
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (0.9.2)
-    mimemagic (0.3.2)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)


### PR DESCRIPTION
Version 0.3.2 was yanked from rubygems.org and is not available for install anymore. Bumping to 0.3.10 which is latest patch version before 0.4.x.

Seems that the only major change is that fd.o database is not distributed with the gem anymore, but most Linux system should already have it preinstalled anyway. It should not cause any issues.