### PR TITLE
fix: error building app docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:3.2.2
 RUN \
     apt-get update \
-    && apt-get install -y --no-install-recommends netcat nodejs \
+    && apt-get install -y --no-install-recommends netcat-traditional nodejs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # throw errors if Gemfile has been modified since Gemfile.lock


### PR DESCRIPTION
According to the
[packages.debian.org](https://packages.debian.org/bookworm/netcat), package `netcat` is a virtual package and does not meant to be installed directly.

Replace `netcat` with `netcat-traditional` to fix image build error.