### PR TITLE
Fix: Duplicate projects language & add test cases for languages controller show action

### DIFF
--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -1,8 +1,11 @@
 class LanguagesController < ApplicationController
   before_action :set_language
 
+  # GET: /languages/:id
+  # filters the projects, users and contributions by language
+  # sets the @projects, @users and @contributions instance variable
   def show
-    @projects = Project.active.by_language(@language).limit(20)
+    @projects = Project.active.by_language(@language).distinct.limit(20)
     @users = User.order('contributions_count desc').by_language(@language).limit(200).sample(45)
     @contributions = Contribution.by_language(@language).year(current_year).latest(5)
   end

--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -31,7 +31,7 @@ class LanguagesController < ApplicationController
   def set_language
     @language = detect_language
 
-    fail(ActionController::RoutingError, "#{language} is not a valid language") if @language.nil?
+    raise(ActionController::RoutingError, "#{language} is not a valid language") if @language.nil?
   end
 
   def language

--- a/spec/controllers/languages_controller_spec.rb
+++ b/spec/controllers/languages_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe LanguagesController, type: :controller do
+  describe 'GET show' do
+    subject(:show) { get :show, params: }
+
+    let!(:project) { FactoryBot.create(:project, inactive:, main_language: language) }
+    let(:inactive) { true }
+    let(:language) { 'Ruby' }
+
+    let(:params) { { id: language_params } }
+    let(:language_params) { language }
+
+    context 'when the language is valid' do
+    end
+
+    context 'when the language is invalid' do
+      let(:language_params) { 'invalid' }
+
+      it 'raises ActionController::RoutingError' do
+        expect { show }.to raise_error(ActionController::RoutingError, 'invalid is not a valid language')
+      end
+    end
+  end
+end

--- a/spec/controllers/languages_controller_spec.rb
+++ b/spec/controllers/languages_controller_spec.rb
@@ -52,6 +52,44 @@ describe LanguagesController, type: :controller do
           expect(assigns(:projects)).to eq([])
         end
       end
+
+      # USERS
+      context 'when there exists contributors for the language' do
+        let(:user1) { FactoryBot.create(:user, contributions_count: 200) }
+        let!(:skill1) { FactoryBot.create(:skill, user: user1, language:) }
+
+        let(:user2) { FactoryBot.create(:user, contributions_count: 230) }
+        let!(:skill2) { FactoryBot.create(:skill, user: user2, language:) }
+
+        it 'sets the @users instance variable sorted by contributions_count' do
+          show
+
+          expect(assigns(:users)).to match_array([user2, user1])
+        end
+      end
+
+      context 'when there exists more than 45 contributors for the language' do
+        let!(:users) do
+          FactoryBot.build_list(:user, 46).each_with_index do |user, _index|
+            FactoryBot.create(:skill, user:, language:)
+            user.save
+          end
+        end
+
+        it 'sets the @users instance variable to a random sample of 45 users' do
+          show
+
+          expect(assigns(:users).count).to eq(45)
+        end
+      end
+
+      context 'when there are no contributors for the language' do
+        it 'sets the @users instance variable to empty' do
+          show
+
+          expect(assigns(:users)).to eq([])
+        end
+      end
     end
 
     context 'when the language is invalid' do

--- a/spec/controllers/languages_controller_spec.rb
+++ b/spec/controllers/languages_controller_spec.rb
@@ -33,6 +33,16 @@ describe LanguagesController, type: :controller do
             expect(assigns(:projects)).to eq([])
           end
         end
+
+        context 'when there are more than 20 projects with the language' do
+          let!(:active_projects) { FactoryBot.create_list(:project, 21, inactive:, main_language: language) }
+
+          it 'sets the @projects instance variable to the first 20 projects' do
+            show
+
+            expect(assigns(:projects).count).to eq(20)
+          end
+        end
       end
 
       context 'when there are no active projects' do

--- a/spec/controllers/languages_controller_spec.rb
+++ b/spec/controllers/languages_controller_spec.rb
@@ -90,6 +90,47 @@ describe LanguagesController, type: :controller do
           expect(assigns(:users)).to eq([])
         end
       end
+
+      # CONTRIBUTIONS
+      context 'when there exists contributions for the language' do
+        let!(:contribution1) { FactoryBot.create(:contribution, language:) }
+
+        context 'when the contribution is during the current year' do
+          it 'sets the @contributions instance variable sorted by contributions_count' do
+            show
+
+            expect(assigns(:contributions)).to match_array([contribution1])
+          end
+        end
+
+        context 'when the contribution is done during the previous year' do
+          before { contribution1.update(created_at: 2.year.ago) }
+
+          it 'sets the @contributions instance variable to empty' do
+            show
+
+            expect(assigns(:contributions)).to eq([])
+          end
+        end
+      end
+
+      context 'when there exists more than 5 contributions for the language' do
+        let!(:contributions) { FactoryBot.create_list(:contribution, 6, language:) }
+
+        it 'sets the @contributions instance variable to a latest 5 contributions' do
+          show
+
+          expect(assigns(:contributions).count).to eq(5)
+        end
+      end
+
+      context 'when there are no contributions for the language' do
+        it 'sets the @contributions instance variable to empty' do
+          show
+
+          expect(assigns(:contributions)).to eq([])
+        end
+      end
     end
 
     context 'when the language is invalid' do

--- a/spec/controllers/languages_controller_spec.rb
+++ b/spec/controllers/languages_controller_spec.rb
@@ -12,6 +12,36 @@ describe LanguagesController, type: :controller do
     let(:language_params) { language }
 
     context 'when the language is valid' do
+      # PROJECTS
+      context 'when there are active projects' do
+        let(:inactive) { false }
+
+        context 'when there are projects with the language' do
+          it 'sets the @projects instance variable to the projects with the language' do
+            show
+
+            expect(assigns(:projects)).to match_array([project])
+          end
+        end
+
+        context 'when there are no projects with the language' do
+          before { project.update(main_language: 'JavaScript') }
+
+          it 'sets the @projects instance variable to empty' do
+            show
+
+            expect(assigns(:projects)).to eq([])
+          end
+        end
+      end
+
+      context 'when there are no active projects' do
+        it 'sets the @projects instance variable to empty' do
+          show
+
+          expect(assigns(:projects)).to eq([])
+        end
+      end
     end
 
     context 'when the language is invalid' do


### PR DESCRIPTION
This PR
* adds the logic to fetch the distinct projects
* adds test cases for the 'show' action in the language controller

Issue: https://github.com/24pullrequests/24pullrequests/issues/4125

Note: This might not fix the actual issue because I believe those are extra database records created rather than the same records appearing twice. Need to check the database.
