### PR TITLE
Update lint for rubocop using mry

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,15 +31,15 @@ AllCops:
     - 'bin/**/*'
     - 'script/**/*'
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Exclude:
     - 'config/unicorn.rb'
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Exclude:
     - 'db/migrate/*devise_create_admin_users.rb'
-Style/AlignHash:
+Layout/HashAlignment:
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table
 Style/Documentation:


### PR DESCRIPTION
This PR fixes the rubocop settings for Ruby 3.2.2.

Process followed:
- `gem install mry`
- `mry .rubocop.yml`