### PR TITLE
Fix 500 error on profile page when deleting only manual contribution

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,15 @@ class UsersController < ApplicationController
 
   def show
     @user      = User.find_by_nickname!(params[:id])
-    @calendar  = Calendar.new(Gift.giftable_dates(current_year), @user.gifts.year(current_year))
+    giftable_dates = Gift.giftable_dates(current_year)
+    user_gifts = @user.gifts.year(current_year)
+    
+    if giftable_dates.any? && user_gifts.any?
+      @calendar = Calendar.new(giftable_dates, user_gifts)
+    else
+      @calendar = nil
+    end
+    
     @merged_contributions = @user.merged_contributions.excluding_organisations(@user.ignored_organisations).year(current_year).latest(nil)
     respond_with @user
   end

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -19,6 +19,7 @@ class Calendar
   alias_method :each_day, :each
 
   def start_padding
+    return 0 if giftable_dates.empty?
     giftable_dates.first.wday - 2
   end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -86,7 +86,13 @@
       </ul>
       <div class="tab-content">
         <div class="tab-pane" id="gifts">
-          <%= render :partial => 'calendar', :object => @calendar %>
+          <% if @calendar %>
+            <%= render :partial => 'calendar', :object => @calendar %>
+          <% else %>
+            <div class="alert alert-info">
+              No gifts to display in calendar view.
+            </div>
+          <% end %>
         </div>
         <div class="tab-pane" id="contributions">
           <%= render partial: 'users/contribution', collection: @user.contributions_ignoring_organisations.year(current_year).latest(nil), cache: true %>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -43,6 +43,22 @@ describe UsersController, type: :controller do
 
         it { is_expected.to respond_with(200) }
       end
+      
+      context 'when user has no gifts' do
+        let(:user_without_gifts) { create :user }
+        
+        before do
+          # Ensure user has no gifts
+          expect(user_without_gifts.gifts.count).to eq(0)
+          get :show, params: {id: user_without_gifts.nickname}
+        end
+        
+        it { is_expected.to respond_with(200) }
+        
+        it 'assigns nil to calendar' do
+          expect(assigns(:calendar)).to be_nil
+        end
+      end
     end
 
     context 'as json' do

--- a/spec/models/calendar_spec.rb
+++ b/spec/models/calendar_spec.rb
@@ -33,4 +33,9 @@ describe Calendar, type: :model do
     calendar = Calendar.new(giftable_dates, [])
     expect(calendar.start_padding).to eq(-1)
   end
+  
+  it 'returns 0 for start_padding when giftable_dates is empty' do
+    calendar = Calendar.new([], [])
+    expect(calendar.start_padding).to eq(0)
+  end
 end

--- a/spec/requests/contributions_spec.rb
+++ b/spec/requests/contributions_spec.rb
@@ -64,4 +64,35 @@ describe 'Contribution', type: :request do
       end
     end
   end
+  
+  describe 'deleting the only manual contribution', js: true do
+    let!(:user) { create :user }
+    let!(:contribution) { create :contribution, :user => user, :state => nil }
+    
+    before do
+      login user
+      # Ensure this is the only contribution
+      expect(user.contributions.count).to eq(1)
+    end
+    
+    it 'can view profile page after deleting manual contribution' do
+      # Delete the contribution
+      visit user_path(user)
+      
+      accept_confirm do
+        click_on "Remove Contribution"
+      end
+      
+      should have_content "Contribution removed successfully!"
+      
+      # Visit the profile page again - this should not cause a 500 error
+      visit user_path(user)
+      
+      # Check that we're on the profile page and it loaded properly
+      should have_content user.nickname
+      should_not have_content 'Edit Contribution'
+      # Check that the contribution count is now 0
+      should have_content "0 contributions"
+    end
+  end
 end


### PR DESCRIPTION
# Fix 500 error on profile page when deleting only manual contribution

## Description
This PR fixes issue #4466 where users experience a 500 error on their profile page after deleting their only manual contribution.

## Problem
When a user deletes their only manual contribution, the profile page attempts to render a calendar with empty collections, causing a 500 error. Specifically, the error occurs in the `Calendar#start_padding` method which tries to access `giftable_dates.first.wday` when there are no giftable dates.

## Solution
1. Added a safety check in the `Calendar#start_padding` method to handle empty giftable_dates
2. Modified the `UsersController#show` method to safely create the Calendar only when both giftable dates and user gifts exist
3. Updated the view to handle cases where the calendar is nil

Fixes #4466